### PR TITLE
feat: Integrate JaCoCo for code coverage and implement missing unit tests

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -224,6 +224,75 @@
                     <password>busticketpwd</password>
                 </configuration>
             </plugin>
+			<plugin>
+            	<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.11</version> 
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>check-coverage</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<configuration>
+							<excludes>
+								<!-- Exclude DTOs -->
+								<exclude>**/dto/**</exclude>
+								<!-- Exclude Entities -->
+								<exclude>**/entity/**</exclude>
+								<!-- Exclude Configuration classes -->
+								<exclude>**/config/**</exclude>
+								<!-- Exclude Exception classes -->
+								<exclude>**/exception/**</exclude>
+								<!-- Exclude Model classes (ApiResponse, BaseEntity, etc.) -->
+								<exclude>**/model/**</exclude>
+								<!-- Exclude Mappers -->
+								<exclude>**/mapper/**</exclude>
+								<!-- Exclude Application main class -->
+								<exclude>**/TicketbookingApplication.class</exclude>
+								<!-- Exclude Converter classes -->
+								<exclude>**/converter/**</exclude>
+								<!-- Exclude Enums -->
+								<exclude>**/enums/**</exclude>
+								<!-- Exclude Scheduler classes -->
+								<exclude>**/scheduler/**</exclude>
+								<!-- Exclude Repository interfaces (Spring Data JPA) -->
+								<exclude>**/repository/**</exclude>
+								<!-- Exclude Controllers (thin, delegate to services) -->
+								<exclude>**/controller/**</exclude>
+								<!-- Exclude Utility classes (simple, already tested) -->
+								<exclude>**/utils/**</exclude>
+							</excludes>
+							<rules>
+								<rule>
+									<element>BUNDLE</element>
+									<limits>
+										<limit>
+											<counter>LINE</counter>
+											<value>COVEREDRATIO</value>
+											<minimum>0.70</minimum>
+										</limit>
+									</limits>
+								</rule>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/backend/src/main/java/com/awad/ticketbooking/modules/catalog/entity/Bus.java
+++ b/backend/src/main/java/com/awad/ticketbooking/modules/catalog/entity/Bus.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.UuidGenerator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import com.awad.ticketbooking.common.converter.StringListConverter;
 import java.util.ArrayList;
@@ -15,6 +16,7 @@ import java.util.UUID;
 @Table(name = "buses")
 @Getter
 @Setter
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class Bus {
 
     @Id

--- a/backend/src/main/java/com/awad/ticketbooking/modules/catalog/entity/Operator.java
+++ b/backend/src/main/java/com/awad/ticketbooking/modules/catalog/entity/Operator.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.UuidGenerator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import com.awad.ticketbooking.common.converter.MapConverter;
 import java.util.Map;
@@ -14,6 +15,7 @@ import java.util.UUID;
 @Table(name = "operators")
 @Getter
 @Setter
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class Operator {
 
     @Id

--- a/backend/src/main/java/com/awad/ticketbooking/modules/catalog/entity/Station.java
+++ b/backend/src/main/java/com/awad/ticketbooking/modules/catalog/entity/Station.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.UuidGenerator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.io.Serializable;
 import java.time.Instant;
@@ -13,6 +14,7 @@ import java.util.UUID;
 @Table(name = "stations")
 @Getter
 @Setter
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class Station implements Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/backend/src/test/java/com/awad/ticketbooking/common/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/common/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,138 @@
+package com.awad.ticketbooking.common.exception;
+
+import com.awad.ticketbooking.common.model.ApiResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class GlobalExceptionHandlerTest {
+
+    @InjectMocks
+    private GlobalExceptionHandler globalExceptionHandler;
+
+    @BeforeEach
+    void setUp() {
+        globalExceptionHandler = new GlobalExceptionHandler();
+    }
+
+    @Test
+    void handleException_returnsInternalServerError() {
+        // Arrange
+        Exception exception = new Exception("Something went wrong");
+
+        // Act
+        ResponseEntity<ApiResponse<Void>> response = globalExceptionHandler.handleException(exception);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(500, response.getBody().status());
+        assertEquals("Something went wrong", response.getBody().message());
+    }
+
+    @Test
+    void handleIllegalArgument_returnsBadRequest() {
+        // Arrange
+        IllegalArgumentException exception = new IllegalArgumentException("Invalid input");
+
+        // Act
+        ResponseEntity<ApiResponse<Void>> response = globalExceptionHandler.handleIllegalArgument(exception);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(400, response.getBody().status());
+        assertEquals("Invalid input", response.getBody().message());
+    }
+
+    @Test
+    void handleAuthorizationDenied_returnsForbidden() {
+        // Arrange
+        AuthorizationDeniedException exception = new AuthorizationDeniedException("Access denied");
+
+        // Act
+        ResponseEntity<ApiResponse<Void>> response = globalExceptionHandler.handleAuthorizationDenied(exception);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(403, response.getBody().status());
+        assertTrue(response.getBody().message().contains("Access Denied"));
+    }
+
+    @Test
+    void handleAccessDenied_returnsForbidden() {
+        // Arrange
+        AccessDeniedException exception = new AccessDeniedException("Access denied");
+
+        // Act
+        ResponseEntity<ApiResponse<Void>> response = globalExceptionHandler.handleAccessDenied(exception);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(403, response.getBody().status());
+        assertTrue(response.getBody().message().contains("Access Denied"));
+    }
+
+    @Test
+    void handleBadCredentials_returnsUnauthorized() {
+        // Arrange
+        BadCredentialsException exception = new BadCredentialsException("Bad credentials");
+
+        // Act
+        ResponseEntity<ApiResponse<Void>> response = globalExceptionHandler.handleBadCredentials(exception);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(401, response.getBody().status());
+    }
+
+    @Test
+    void handleImageUploadException_returnsBadRequest() {
+        // Arrange
+        ImageUploadException exception = new ImageUploadException("Image upload failed");
+
+        // Act
+        ResponseEntity<ApiResponse<Void>> response = globalExceptionHandler.handleImageUploadException(exception);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(400, response.getBody().status());
+        assertEquals("Image upload failed", response.getBody().message());
+    }
+
+    @Test
+    void handleResourceNotFound_returnsNotFound() {
+        // Arrange
+        ResourceNotFoundException exception = new ResourceNotFoundException("Resource not found");
+
+        // Act
+        ResponseEntity<ApiResponse<Void>> response = globalExceptionHandler.handleResourceNotFound(exception);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(404, response.getBody().status());
+        assertEquals("Resource not found", response.getBody().message());
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/common/service/EmailServiceTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/common/service/EmailServiceTest.java
@@ -1,0 +1,161 @@
+package com.awad.ticketbooking.common.service;
+
+import com.awad.ticketbooking.common.enums.BookingStatus;
+import com.awad.ticketbooking.modules.booking.entity.Booking;
+import com.awad.ticketbooking.modules.booking.entity.Ticket;
+import com.awad.ticketbooking.modules.catalog.entity.Bus;
+import com.awad.ticketbooking.modules.catalog.entity.Operator;
+import com.awad.ticketbooking.modules.catalog.entity.Route;
+import com.awad.ticketbooking.modules.catalog.entity.Station;
+import com.awad.ticketbooking.modules.trip.entity.Trip;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class EmailServiceTest {
+
+    @InjectMocks
+    private EmailService emailService;
+
+    @Mock
+    private JavaMailSender mailSender;
+
+    @Mock
+    private MimeMessage mimeMessage;
+
+    private Booking testBooking;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(emailService, "fromEmail", "test@example.com");
+        ReflectionTestUtils.setField(emailService, "fromName", "Bus Ticket Booking");
+
+        // Setup stations
+        Station originStation = new Station();
+        originStation.setId(UUID.randomUUID());
+        originStation.setName("Hanoi Station");
+        originStation.setCity("Hanoi");
+
+        Station destStation = new Station();
+        destStation.setId(UUID.randomUUID());
+        destStation.setName("Saigon Station");
+        destStation.setCity("Saigon");
+
+        // Setup route
+        Route route = new Route();
+        route.setId(UUID.randomUUID());
+        route.setOriginStation(originStation);
+        route.setDestinationStation(destStation);
+
+        // Setup operator
+        Operator operator = new Operator();
+        operator.setId(UUID.randomUUID());
+        operator.setName("VietBus");
+
+        // Setup bus
+        Bus bus = new Bus();
+        bus.setId(UUID.randomUUID());
+        bus.setPlateNumber("29A-12345");
+        bus.setOperator(operator);
+
+        // Setup trip
+        Trip trip = new Trip();
+        trip.setId(UUID.randomUUID());
+        trip.setRoute(route);
+        trip.setBus(bus);
+        trip.setDepartureTime(Instant.now().plusSeconds(86400));
+
+        // Setup booking
+        testBooking = new Booking();
+        testBooking.setId(UUID.randomUUID());
+        testBooking.setCode("BK-ABC123");
+        testBooking.setTrip(trip);
+        testBooking.setPassengerName("Test Passenger");
+        testBooking.setPassengerPhone("0123456789");
+        testBooking.setStatus(BookingStatus.CONFIRMED);
+        testBooking.setTotalPrice(new BigDecimal("200000"));
+        testBooking.setPickupStation(originStation);
+
+        Ticket ticket = new Ticket();
+        ticket.setId(UUID.randomUUID());
+        ticket.setBooking(testBooking);
+        ticket.setSeatCode("A1");
+        ticket.setPassengerName("Test Passenger");
+        testBooking.setTickets(new ArrayList<>(Collections.singletonList(ticket)));
+    }
+
+    @Test
+    void sendBookingConfirmationEmail_success() {
+        // Arrange
+        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+        doNothing().when(mailSender).send(any(MimeMessage.class));
+
+        // Act
+        emailService.sendBookingConfirmationEmail(testBooking, "test@example.com");
+
+        // Assert
+        verify(mailSender).createMimeMessage();
+        verify(mailSender).send(any(MimeMessage.class));
+    }
+
+    @Test
+    void sendTripReminderEmail_success() {
+        // Arrange
+        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+        doNothing().when(mailSender).send(any(MimeMessage.class));
+
+        // Act
+        emailService.sendTripReminderEmail(testBooking, "test@example.com");
+
+        // Assert
+        verify(mailSender).createMimeMessage();
+        verify(mailSender).send(any(MimeMessage.class));
+    }
+
+    @Test
+    void sendActivationEmail_success() {
+        // Arrange
+        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+        doNothing().when(mailSender).send(any(MimeMessage.class));
+
+        // Act
+        emailService.sendActivationEmail("test@example.com", "Test User", "activation-token");
+
+        // Assert
+        verify(mailSender).createMimeMessage();
+        verify(mailSender).send(any(MimeMessage.class));
+    }
+
+    @Test
+    void sendPasswordResetEmail_success() {
+        // Arrange
+        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+        doNothing().when(mailSender).send(any(MimeMessage.class));
+
+        // Act
+        emailService.sendPasswordResetEmail("test@example.com", "Test User", "reset-token");
+
+        // Assert
+        verify(mailSender).createMimeMessage();
+        verify(mailSender).send(any(MimeMessage.class));
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/common/utils/DateUtilsTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/common/utils/DateUtilsTest.java
@@ -1,0 +1,71 @@
+package com.awad.ticketbooking.common.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DateUtilsTest {
+
+    @Test
+    void nowUtc_shouldReturnCurrentInstant() {
+        // Act
+        Instant result = DateUtils.nowUtc();
+
+        // Assert
+        assertNotNull(result);
+        // Should be very close to now (within 1 second)
+        Instant now = Instant.now();
+        long diff = Math.abs(now.toEpochMilli() - result.toEpochMilli());
+        assertTrue(diff < 1000, "Should return current time within 1 second");
+    }
+
+    @Test
+    void formatIso_shouldFormatInstantCorrectly() {
+        // Arrange
+        Instant instant = Instant.parse("2024-01-15T10:30:00Z");
+        
+        // Act
+        String result = DateUtils.formatIso(instant);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result.contains("2024-01-15"));
+        assertTrue(result.contains("10:30:00"));
+        // Should be in UTC format
+        assertTrue(result.endsWith("Z") || result.contains("+00:00"));
+    }
+
+    @Test
+    void formatIso_withDifferentInstants_shouldFormatCorrectly() {
+        // Arrange
+        Instant instant1 = Instant.parse("2023-12-25T00:00:00Z");
+        Instant instant2 = Instant.parse("2025-06-30T23:59:59Z");
+
+        // Act
+        String result1 = DateUtils.formatIso(instant1);
+        String result2 = DateUtils.formatIso(instant2);
+
+        // Assert
+        assertNotNull(result1);
+        assertNotNull(result2);
+        assertTrue(result1.contains("2023-12-25"));
+        assertTrue(result2.contains("2025-06-30"));
+    }
+
+    @Test
+    void formatIso_withEpochSecond_shouldFormatCorrectly() {
+        // Arrange
+        Instant instant = Instant.ofEpochSecond(1705312200); // 2024-01-15T10:30:00Z
+
+        // Act
+        String result = DateUtils.formatIso(instant);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result.contains("2024"));
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/common/utils/QrCodeUtilsTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/common/utils/QrCodeUtilsTest.java
@@ -1,0 +1,64 @@
+package com.awad.ticketbooking.common.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class QrCodeUtilsTest {
+
+    @Test
+    void generateQrCodeImage_success() {
+        // Act
+        byte[] result = QrCodeUtils.generateQrCodeImage("BK-ABC123", 200, 200);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result.length > 0);
+    }
+
+    @Test
+    void generateQrCodeImage_withLongText_success() {
+        // Arrange
+        String longText = "https://example.com/booking/verify?code=BK-ABC123&token=abcdefghijklmnop";
+
+        // Act
+        byte[] result = QrCodeUtils.generateQrCodeImage(longText, 300, 300);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result.length > 0);
+    }
+
+    @Test
+    void generateQrCodeImage_smallSize_success() {
+        // Act
+        byte[] result = QrCodeUtils.generateQrCodeImage("TEST", 50, 50);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result.length > 0);
+    }
+
+    @Test
+    void generateQrCodeImage_largeSize_success() {
+        // Act
+        byte[] result = QrCodeUtils.generateQrCodeImage("TEST", 500, 500);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result.length > 0);
+    }
+
+    @Test
+    void generateQrCodeImage_withSpecialCharacters_success() {
+        // Arrange
+        String specialText = "Mã vé: BK-ABC123 - Điểm đón: Hà Nội";
+
+        // Act
+        byte[] result = QrCodeUtils.generateQrCodeImage(specialText, 200, 200);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result.length > 0);
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/ai/controller/AiChatControllerTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/ai/controller/AiChatControllerTest.java
@@ -1,0 +1,61 @@
+package com.awad.ticketbooking.modules.ai.controller;
+
+import com.awad.ticketbooking.modules.ai.dto.ChatRequest;
+import com.awad.ticketbooking.modules.ai.dto.ChatResponse;
+import com.awad.ticketbooking.modules.ai.service.AiChatService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class AiChatControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private AiChatService aiChatService;
+
+    @InjectMocks
+    private AiChatController aiChatController;
+
+    private ObjectMapper objectMapper;
+    private ChatResponse mockChatResponse;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(aiChatController).build();
+        objectMapper = new ObjectMapper();
+
+        mockChatResponse = new ChatResponse("Hello! How can I help you?");
+    }
+
+    @Test
+    void chat_success() throws Exception {
+        // Arrange
+        ChatRequest request = new ChatRequest();
+        request.setMessage("Hello");
+        request.setUserId(java.util.UUID.randomUUID());
+        when(aiChatService.getChatResponse(any(ChatRequest.class))).thenReturn(mockChatResponse);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/v1/ai/chat")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reply").value("Hello! How can I help you?"));
+
+        verify(aiChatService).getChatResponse(any(ChatRequest.class));
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/ai/service/AiChatServiceTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/ai/service/AiChatServiceTest.java
@@ -1,0 +1,172 @@
+package com.awad.ticketbooking.modules.ai.service;
+
+import com.awad.ticketbooking.modules.ai.dto.ChatRequest;
+import com.awad.ticketbooking.modules.ai.dto.ChatResponse;
+import com.awad.ticketbooking.modules.auth.entity.User;
+import com.awad.ticketbooking.modules.auth.repository.UserRepository;
+import com.awad.ticketbooking.modules.booking.service.BookingService;
+import com.awad.ticketbooking.modules.catalog.service.BusLayoutService;
+import com.awad.ticketbooking.modules.trip.service.TripService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AiChatServiceTest {
+
+    @InjectMocks
+    private AiChatService aiChatService;
+
+    @Mock
+    private TripService tripService;
+
+    @Mock
+    private BookingService bookingService;
+
+    @Mock
+    private BusLayoutService busLayoutService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    private User testUser;
+    private ChatRequest chatRequest;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(aiChatService, "apiKey", "test-api-key");
+
+        testUser = new User();
+        testUser.setId(UUID.randomUUID());
+        testUser.setEmail("test@example.com");
+        testUser.setFullName("Test User");
+
+        chatRequest = new ChatRequest();
+        chatRequest.setMessage("Hello");
+    }
+
+    @Test
+    void getChatResponse_withGuestUser_handlesGracefully() {
+        // Arrange
+        chatRequest.setUserId(null);
+
+        // Act & Assert
+        // Since the service uses external API, we expect it to handle exceptions
+        // The actual implementation will throw an exception when trying to create Client
+        // but we're testing that it returns an error response rather than crashing
+        assertDoesNotThrow(() -> {
+            ChatResponse response = aiChatService.getChatResponse(chatRequest);
+            assertNotNull(response);
+            // The response will contain an error message due to API call failure in test
+        });
+    }
+
+    @Test
+    void getChatResponse_withLoggedInUser_handlesGracefully() {
+        // Arrange
+        UUID userId = UUID.randomUUID();
+        chatRequest.setUserId(userId);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
+
+        // Act & Assert
+        assertDoesNotThrow(() -> {
+            ChatResponse response = aiChatService.getChatResponse(chatRequest);
+            assertNotNull(response);
+            // The response will contain an error message due to API call failure in test
+        });
+    }
+
+    @Test
+    void getChatResponse_withInvalidUserId_handlesGracefully() {
+        // Arrange
+        UUID invalidUserId = UUID.randomUUID();
+        chatRequest.setUserId(invalidUserId);
+        when(userRepository.findById(invalidUserId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertDoesNotThrow(() -> {
+            ChatResponse response = aiChatService.getChatResponse(chatRequest);
+            assertNotNull(response);
+        });
+    }
+
+    @Test
+    void getChatResponse_withException_returnsErrorResponse() {
+        // Arrange
+        chatRequest.setUserId(null);
+        // The service will fail when trying to create Client with invalid API key
+        // but should catch the exception and return an error response
+
+        // Act
+        ChatResponse response = aiChatService.getChatResponse(chatRequest);
+
+        // Assert
+        assertNotNull(response);
+        assertNotNull(response.getReply());
+        // Should contain error message
+        assertTrue(response.getReply().contains("Lỗi") || response.getReply().contains("error") || 
+                   response.getReply().contains("Error") || response.getReply().length() > 0);
+    }
+
+    @Test
+    void getChatResponse_maintainsChatHistory() {
+        // Arrange
+        chatRequest.setUserId(null);
+        String userId = "GUEST";
+
+        // Act - call multiple times
+        aiChatService.getChatResponse(chatRequest);
+        aiChatService.getChatResponse(chatRequest);
+
+        // Assert - verify that history is maintained (indirectly through service behavior)
+        // Since we can't directly access the private chatHistory map, we verify through behavior
+        assertDoesNotThrow(() -> {
+            ChatResponse response = aiChatService.getChatResponse(chatRequest);
+            assertNotNull(response);
+        });
+    }
+
+    @Test
+    void getChatResponse_withNullMessage_handlesGracefully() {
+        // Arrange
+        chatRequest.setMessage(null);
+        chatRequest.setUserId(null);
+
+        // Act & Assert
+        assertDoesNotThrow(() -> {
+            ChatResponse response = aiChatService.getChatResponse(chatRequest);
+            assertNotNull(response);
+        });
+    }
+
+    @Test
+    void getChatResponse_withEmptyMessage_handlesGracefully() {
+        // Arrange
+        chatRequest.setMessage("");
+        chatRequest.setUserId(null);
+
+        // Act & Assert
+        assertDoesNotThrow(() -> {
+            ChatResponse response = aiChatService.getChatResponse(chatRequest);
+            assertNotNull(response);
+        });
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/auth/controller/AuthControllerTest.java
@@ -1,0 +1,230 @@
+package com.awad.ticketbooking.modules.auth.controller;
+
+import com.awad.ticketbooking.common.config.JwtProperties;
+import com.awad.ticketbooking.common.config.security.ApplicationUserDetails;
+import com.awad.ticketbooking.modules.auth.dto.AuthResponse;
+import com.awad.ticketbooking.modules.auth.dto.ForgotPasswordRequest;
+import com.awad.ticketbooking.modules.auth.dto.GoogleLoginRequest;
+import com.awad.ticketbooking.modules.auth.dto.LoginRequest;
+import com.awad.ticketbooking.modules.auth.dto.RegisterRequest;
+import com.awad.ticketbooking.modules.auth.dto.ResetPasswordRequest;
+import com.awad.ticketbooking.modules.auth.dto.UserResponse;
+import com.awad.ticketbooking.modules.auth.entity.AuthProvider;
+import com.awad.ticketbooking.modules.auth.entity.User;
+import com.awad.ticketbooking.modules.auth.entity.UserRole;
+import com.awad.ticketbooking.modules.auth.service.AuthService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockCookie;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+@org.mockito.junit.jupiter.MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
+class AuthControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private AuthService authService;
+
+    @Mock
+    private JwtProperties jwtProperties;
+
+    @InjectMocks
+    private AuthController authController;
+
+    private ObjectMapper objectMapper;
+    private AuthService.AuthResult mockAuthResult;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(authController).build();
+        objectMapper = new ObjectMapper();
+
+        UserResponse userResponse = new UserResponse(
+                UUID.randomUUID(),
+                "Test User",
+                "test@example.com",
+                "0123456789",
+                UserRole.PASSENGER,
+                null,
+                AuthProvider.LOCAL
+        );
+        AuthResponse authResponse = new AuthResponse("access-token", userResponse);
+        mockAuthResult = new AuthService.AuthResult(authResponse, "refresh-token");
+
+        when(jwtProperties.refreshTokenTtl()).thenReturn(Duration.ofDays(7));
+    }
+
+    @Test
+    void register_success() throws Exception {
+        // Arrange
+        RegisterRequest request = new RegisterRequest(
+                "Test User",
+                "test@example.com",
+                "Password123!"
+        );
+        doNothing().when(authService).register(any(RegisterRequest.class));
+
+        // Act & Assert
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Registration successful. Please check your email to activate your account."));
+
+        verify(authService).register(any(RegisterRequest.class));
+    }
+
+    @Test
+    void activate_success() throws Exception {
+        // Arrange
+        when(authService.activateAccount(anyString())).thenReturn(mockAuthResult);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/auth/activate")
+                        .param("token", "activation-token"))
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("refresh_token"))
+                .andExpect(jsonPath("$.data.accessToken").value("access-token"));
+
+        verify(authService).activateAccount("activation-token");
+    }
+
+    @Test
+    void forgotPassword_success() throws Exception {
+        // Arrange
+        ForgotPasswordRequest request = new ForgotPasswordRequest("test@example.com");
+        doNothing().when(authService).initiatePasswordReset(anyString());
+
+        // Act & Assert
+        mockMvc.perform(post("/api/auth/forgot-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("If your email is registered, you will receive a password reset link shortly."));
+
+        verify(authService).initiatePasswordReset("test@example.com");
+    }
+
+    @Test
+    void resetPassword_success() throws Exception {
+        // Arrange
+        ResetPasswordRequest request = new ResetPasswordRequest("reset-token", "NewPassword123!");
+        doNothing().when(authService).resetPassword(anyString(), anyString());
+
+        // Act & Assert
+        mockMvc.perform(post("/api/auth/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Password reset successful. You can now login."));
+
+        verify(authService).resetPassword("reset-token", "NewPassword123!");
+    }
+
+    @Test
+    void login_success() throws Exception {
+        // Arrange
+        LoginRequest request = new LoginRequest("test@example.com", "password123");
+        when(authService.login(any(LoginRequest.class))).thenReturn(mockAuthResult);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("refresh_token"))
+                .andExpect(jsonPath("$.data.accessToken").value("access-token"));
+
+        verify(authService).login(any(LoginRequest.class));
+    }
+
+    @Test
+    void loginWithGoogle_success() throws Exception {
+        // Arrange
+        GoogleLoginRequest request = new GoogleLoginRequest("google-credential");
+        when(authService.loginWithGoogle(any(GoogleLoginRequest.class))).thenReturn(mockAuthResult);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/auth/google")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("refresh_token"))
+                .andExpect(jsonPath("$.data.accessToken").value("access-token"));
+
+        verify(authService).loginWithGoogle(any(GoogleLoginRequest.class));
+    }
+
+    @Test
+    void refresh_success() throws Exception {
+        // Arrange
+        when(authService.refresh(anyString())).thenReturn(mockAuthResult);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/auth/refresh")
+                        .cookie(new MockCookie("refresh_token", "refresh-token")))
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("refresh_token"))
+                .andExpect(jsonPath("$.data.accessToken").value("access-token"));
+
+        verify(authService).refresh("refresh-token");
+    }
+
+    @Test
+    void refresh_missingToken_returns401() throws Exception {
+        // Act & Assert
+        mockMvc.perform(post("/api/auth/refresh"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("Missing refresh token"));
+
+        verify(authService, never()).refresh(anyString());
+    }
+
+    @Test
+    void logout_success() throws Exception {
+        // Arrange
+        // Note: In standalone setup, @AuthenticationPrincipal is not automatically injected
+        // This test verifies the endpoint works when user is null (no authentication)
+        // Full authentication testing requires integration tests with Spring Security context
+
+        // Act & Assert
+        mockMvc.perform(post("/api/auth/logout"))
+                .andExpect(status().isOk())
+                .andExpect(cookie().value("refresh_token", ""))
+                .andExpect(jsonPath("$.message").value("Logged out"));
+
+        // When user is null, logout should not call authService
+        verify(authService, never()).logout(any(User.class));
+    }
+
+    @Test
+    void logout_withoutUser_success() throws Exception {
+        // Act & Assert
+        mockMvc.perform(post("/api/auth/logout"))
+                .andExpect(status().isOk())
+                .andExpect(cookie().value("refresh_token", ""))
+                .andExpect(jsonPath("$.message").value("Logged out"));
+
+        verify(authService, never()).logout(any(User.class));
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/auth/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/auth/controller/UserControllerTest.java
@@ -1,0 +1,179 @@
+package com.awad.ticketbooking.modules.auth.controller;
+
+import com.awad.ticketbooking.common.config.security.ApplicationUserDetails;
+import com.awad.ticketbooking.modules.auth.dto.ChangePasswordRequest;
+import com.awad.ticketbooking.modules.auth.dto.UpdateAvatarRequest;
+import com.awad.ticketbooking.modules.auth.dto.UpdateProfileRequest;
+import com.awad.ticketbooking.modules.auth.dto.UserResponse;
+import com.awad.ticketbooking.modules.auth.entity.User;
+import com.awad.ticketbooking.modules.auth.entity.UserRole;
+import com.awad.ticketbooking.common.exception.GlobalExceptionHandler;
+import com.awad.ticketbooking.modules.auth.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private UserController userController;
+
+    private ObjectMapper objectMapper;
+    private User testUser;
+    private ApplicationUserDetails userDetails;
+
+    @BeforeEach
+    void setUp() {
+        // Create a custom argument resolver that works with SecurityContext
+        AuthenticationPrincipalArgumentResolver resolver = new AuthenticationPrincipalArgumentResolver();
+        
+        mockMvc = MockMvcBuilders.standaloneSetup(userController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setCustomArgumentResolvers(resolver)
+                .build();
+        objectMapper = new ObjectMapper();
+
+        testUser = User.builder()
+                .email("test@example.com")
+                .fullName("Test User")
+                .role(UserRole.PASSENGER)
+                .build();
+        testUser.setId(UUID.randomUUID());
+        userDetails = new ApplicationUserDetails(testUser);
+    }
+    
+    private void setupSecurityContext() {
+        SecurityContext context = new SecurityContextImpl();
+        Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        context.setAuthentication(auth);
+        SecurityContextHolder.setContext(context);
+    }
+    
+    private void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void me_success() throws Exception {
+        try {
+            setupSecurityContext();
+            // Act & Assert
+            mockMvc.perform(get("/api/users/me")
+                            .with(SecurityMockMvcRequestPostProcessors.user(userDetails)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.email").value("test@example.com"));
+        } finally {
+            clearSecurityContext();
+        }
+    }
+
+    @Test
+    void me_unauthorized() throws Exception {
+        // Act & Assert - Without authentication, should throw IllegalStateException
+        mockMvc.perform(get("/api/users/me"))
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    void updateProfile_success() throws Exception {
+        try {
+            setupSecurityContext();
+            // Arrange
+            UpdateProfileRequest request = new UpdateProfileRequest("Updated Name", "0123456789");
+            User updatedUser = User.builder()
+                    .fullName("Updated Name")
+                    .phone("0123456789")
+                    .build();
+            updatedUser.setId(testUser.getId());
+            when(userService.updateProfile(eq(testUser), any(UpdateProfileRequest.class))).thenReturn(updatedUser);
+
+            // Act & Assert
+            mockMvc.perform(put("/api/users/me/profile")
+                            .with(SecurityMockMvcRequestPostProcessors.user(userDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.fullName").value("Updated Name"));
+
+            verify(userService).updateProfile(eq(testUser), any(UpdateProfileRequest.class));
+        } finally {
+            clearSecurityContext();
+        }
+    }
+
+    @Test
+    void changePassword_success() throws Exception {
+        try {
+            setupSecurityContext();
+            // Arrange
+            ChangePasswordRequest request = new ChangePasswordRequest("oldPassword", "newPassword1!");
+            doNothing().when(userService).changePassword(any(User.class), any(ChangePasswordRequest.class));
+
+            // Act & Assert
+            mockMvc.perform(put("/api/users/me/password")
+                            .with(SecurityMockMvcRequestPostProcessors.user(userDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("Password changed successfully"));
+
+            verify(userService).changePassword(eq(testUser), any(ChangePasswordRequest.class));
+        } finally {
+            clearSecurityContext();
+        }
+    }
+
+    @Test
+    void updateAvatar_success() throws Exception {
+        try {
+            setupSecurityContext();
+            // Arrange
+            UpdateAvatarRequest request = new UpdateAvatarRequest("https://example.com/avatar.jpg");
+            User updatedUser = User.builder()
+                    .avatarUrl("https://example.com/avatar.jpg")
+                    .build();
+            updatedUser.setId(testUser.getId());
+            when(userService.updateAvatar(eq(testUser), any(UpdateAvatarRequest.class))).thenReturn(updatedUser);
+
+            // Act & Assert
+            mockMvc.perform(put("/api/users/me/avatar")
+                            .with(SecurityMockMvcRequestPostProcessors.user(userDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.avatarUrl").value("https://example.com/avatar.jpg"));
+
+            verify(userService).updateAvatar(eq(testUser), any(UpdateAvatarRequest.class));
+        } finally {
+            clearSecurityContext();
+        }
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/auth/service/AdminUserServiceTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/auth/service/AdminUserServiceTest.java
@@ -1,0 +1,311 @@
+package com.awad.ticketbooking.modules.auth.service;
+
+import com.awad.ticketbooking.modules.auth.dto.CreateAdminRequest;
+import com.awad.ticketbooking.modules.auth.dto.UpdateAdminRequest;
+import com.awad.ticketbooking.modules.auth.entity.AuthProvider;
+import com.awad.ticketbooking.modules.auth.entity.User;
+import com.awad.ticketbooking.modules.auth.entity.UserRole;
+import com.awad.ticketbooking.modules.auth.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AdminUserServiceTest {
+
+    @InjectMocks
+    private AdminUserService adminUserService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    private User testUser;
+    private User adminUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .email("test@example.com")
+                .fullName("Test User")
+                .phone("0123456789")
+                .passwordHash("encoded-password")
+                .authProvider(AuthProvider.LOCAL)
+                .build();
+        testUser.setId(UUID.randomUUID());
+        testUser.setRole(UserRole.PASSENGER);
+        testUser.setEnabled(true);
+
+        adminUser = User.builder()
+                .email("admin@example.com")
+                .fullName("Admin User")
+                .phone("0987654321")
+                .passwordHash("encoded-password")
+                .authProvider(AuthProvider.LOCAL)
+                .build();
+        adminUser.setId(UUID.randomUUID());
+        adminUser.setRole(UserRole.ADMIN);
+        adminUser.setEnabled(true);
+    }
+
+    @Test
+    void getAllUsers_withoutRole_returnsAllUsers() {
+        // Arrange
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<User> page = new PageImpl<>(Collections.singletonList(testUser));
+        when(userRepository.findAll(pageable)).thenReturn(page);
+
+        // Act
+        Page<User> result = adminUserService.getAllUsers(null, pageable);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        verify(userRepository).findAll(pageable);
+    }
+
+    @Test
+    void getAllUsers_withRole_returnsFilteredUsers() {
+        // Arrange
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<User> page = new PageImpl<>(Collections.singletonList(adminUser));
+        when(userRepository.findByRole(UserRole.ADMIN, pageable)).thenReturn(page);
+
+        // Act
+        Page<User> result = adminUserService.getAllUsers(UserRole.ADMIN, pageable);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        verify(userRepository).findByRole(UserRole.ADMIN, pageable);
+    }
+
+    @Test
+    void getUserById_success() {
+        // Arrange
+        when(userRepository.findById(testUser.getId())).thenReturn(Optional.of(testUser));
+
+        // Act
+        User result = adminUserService.getUserById(testUser.getId());
+
+        // Assert
+        assertNotNull(result);
+        assertEquals("Test User", result.getFullName());
+    }
+
+    @Test
+    void getUserById_notFound_throwsException() {
+        // Arrange
+        UUID nonExistentId = UUID.randomUUID();
+        when(userRepository.findById(nonExistentId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> adminUserService.getUserById(nonExistentId));
+        assertTrue(exception.getMessage().contains("User not found"));
+    }
+
+    @Test
+    void createAdmin_success() {
+        // Arrange
+        CreateAdminRequest request = new CreateAdminRequest(
+                "newadmin@example.com",
+                "New Admin",
+                "0111222333",
+                "password123"
+        );
+
+        when(userRepository.findByEmail("newadmin@example.com")).thenReturn(Optional.empty());
+        when(userRepository.findByPhone("0111222333")).thenReturn(Optional.empty());
+        when(passwordEncoder.encode("password123")).thenReturn("encoded-new-password");
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            User u = invocation.getArgument(0);
+            u.setId(UUID.randomUUID());
+            return u;
+        });
+
+        // Act
+        User result = adminUserService.createAdmin(request);
+
+        // Assert
+        assertNotNull(result);
+        verify(userRepository).save(any(User.class));
+        verify(passwordEncoder).encode("password123");
+    }
+
+    @Test
+    void createAdmin_emailExists_throwsException() {
+        // Arrange
+        CreateAdminRequest request = new CreateAdminRequest(
+                "test@example.com",
+                "New Admin",
+                "0111222333",
+                "password123"
+        );
+
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(testUser));
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> adminUserService.createAdmin(request));
+        assertEquals("Email already in use", exception.getMessage());
+    }
+
+    @Test
+    void createAdmin_phoneExists_throwsException() {
+        // Arrange
+        CreateAdminRequest request = new CreateAdminRequest(
+                "newadmin@example.com",
+                "New Admin",
+                "0123456789",
+                "password123"
+        );
+
+        when(userRepository.findByEmail("newadmin@example.com")).thenReturn(Optional.empty());
+        when(userRepository.findByPhone("0123456789")).thenReturn(Optional.of(testUser));
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> adminUserService.createAdmin(request));
+        assertEquals("Phone number already in use", exception.getMessage());
+    }
+
+    @Test
+    void createAdmin_nullPhone_success() {
+        // Arrange
+        CreateAdminRequest request = new CreateAdminRequest(
+                "newadmin@example.com",
+                "New Admin",
+                null,
+                "password123"
+        );
+
+        when(userRepository.findByEmail("newadmin@example.com")).thenReturn(Optional.empty());
+        when(passwordEncoder.encode("password123")).thenReturn("encoded-new-password");
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            User u = invocation.getArgument(0);
+            u.setId(UUID.randomUUID());
+            return u;
+        });
+
+        // Act
+        User result = adminUserService.createAdmin(request);
+
+        // Assert
+        assertNotNull(result);
+        verify(userRepository, never()).findByPhone(anyString());
+    }
+
+    @Test
+    void updateAdmin_success() {
+        // Arrange
+        UpdateAdminRequest request = new UpdateAdminRequest("Updated Admin", "0999888777");
+        when(userRepository.findById(adminUser.getId())).thenReturn(Optional.of(adminUser));
+        when(userRepository.findByPhone("0999888777")).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenReturn(adminUser);
+
+        // Act
+        User result = adminUserService.updateAdmin(adminUser.getId(), request);
+
+        // Assert
+        assertNotNull(result);
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void updateAdmin_notAdmin_throwsException() {
+        // Arrange
+        UpdateAdminRequest request = new UpdateAdminRequest("Updated User", "0999888777");
+        when(userRepository.findById(testUser.getId())).thenReturn(Optional.of(testUser));
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> adminUserService.updateAdmin(testUser.getId(), request));
+        assertEquals("Can only update admin users via this endpoint", exception.getMessage());
+    }
+
+    @Test
+    void updateAdmin_phoneExists_throwsException() {
+        // Arrange
+        User otherAdmin = User.builder()
+                .email("other@example.com")
+                .phone("0999888777")
+                .build();
+        otherAdmin.setId(UUID.randomUUID());
+
+        UpdateAdminRequest request = new UpdateAdminRequest("Updated Admin", "0999888777");
+        when(userRepository.findById(adminUser.getId())).thenReturn(Optional.of(adminUser));
+        when(userRepository.findByPhone("0999888777")).thenReturn(Optional.of(otherAdmin));
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> adminUserService.updateAdmin(adminUser.getId(), request));
+        assertEquals("Phone number already in use", exception.getMessage());
+    }
+
+    @Test
+    void updateAdmin_samePhone_success() {
+        // Arrange
+        UpdateAdminRequest request = new UpdateAdminRequest("Updated Admin", "0987654321");
+        when(userRepository.findById(adminUser.getId())).thenReturn(Optional.of(adminUser));
+        when(userRepository.findByPhone("0987654321")).thenReturn(Optional.of(adminUser));
+        when(userRepository.save(any(User.class))).thenReturn(adminUser);
+
+        // Act
+        User result = adminUserService.updateAdmin(adminUser.getId(), request);
+
+        // Assert
+        assertNotNull(result);
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void setUserStatus_enable_success() {
+        // Arrange
+        testUser.setEnabled(false);
+        when(userRepository.findById(testUser.getId())).thenReturn(Optional.of(testUser));
+        when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+        // Act
+        User result = adminUserService.setUserStatus(testUser.getId(), true);
+
+        // Assert
+        assertNotNull(result);
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void setUserStatus_disable_success() {
+        // Arrange
+        when(userRepository.findById(testUser.getId())).thenReturn(Optional.of(testUser));
+        when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+        // Act
+        User result = adminUserService.setUserStatus(testUser.getId(), false);
+
+        // Assert
+        assertNotNull(result);
+        verify(userRepository).save(any(User.class));
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/auth/service/AuthServiceTest.java
@@ -1,13 +1,19 @@
 package com.awad.ticketbooking.modules.auth.service;
 
 import com.awad.ticketbooking.common.service.EmailService;
+import com.awad.ticketbooking.modules.auth.dto.GoogleLoginRequest;
 import com.awad.ticketbooking.modules.auth.dto.LoginRequest;
 import com.awad.ticketbooking.modules.auth.dto.RegisterRequest;
+import com.awad.ticketbooking.modules.auth.entity.AuthProvider;
+import com.awad.ticketbooking.modules.auth.entity.PasswordResetToken;
 import com.awad.ticketbooking.modules.auth.entity.RefreshToken;
 import com.awad.ticketbooking.modules.auth.entity.User;
 import com.awad.ticketbooking.modules.auth.entity.UserRole;
+import com.awad.ticketbooking.modules.auth.repository.PasswordResetTokenRepository;
 import com.awad.ticketbooking.modules.auth.repository.UserRepository;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -18,12 +24,15 @@ import org.mockito.quality.Strictness;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -46,6 +55,23 @@ class AuthServiceTest {
     private GoogleIdTokenVerifier googleIdTokenVerifier;
     @Mock
     private EmailService emailService;
+    @Mock
+    private PasswordResetTokenRepository passwordResetTokenRepository;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .email("test@example.com")
+                .fullName("Test User")
+                .passwordHash("encoded-password")
+                .enabled(true)
+                .role(UserRole.PASSENGER)
+                .authProvider(AuthProvider.LOCAL)
+                .build();
+        testUser.setId(UUID.randomUUID());
+    }
 
     @Test
     void testRegister() {
@@ -88,5 +114,302 @@ class AuthServiceTest {
         when(refreshTokenService.create(any(User.class))).thenReturn(new RefreshToken());
 
         assertDoesNotThrow(() -> authService.login(request));
+    }
+
+    @Test
+    void register_emailAlreadyExists_throwsException() {
+        // Arrange
+        RegisterRequest request = new RegisterRequest("Test", "test@example.com", "password");
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(testUser));
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> authService.register(request));
+        assertEquals("Email already registered", exception.getMessage());
+    }
+
+    @Test
+    void activateAccount_success() {
+        // Arrange
+        String token = UUID.randomUUID().toString();
+        testUser.setEnabled(false);
+        testUser.setActivationToken(token);
+        testUser.setActivationTokenExpiry(Instant.now().plusSeconds(3600));
+
+        when(userRepository.findByActivationToken(token)).thenReturn(Optional.of(testUser));
+        when(userRepository.save(any(User.class))).thenReturn(testUser);
+        when(jwtService.generateAccessToken(any(User.class))).thenReturn("access-token");
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setToken("refresh-token");
+        when(refreshTokenService.create(any(User.class))).thenReturn(refreshToken);
+
+        // Act
+        AuthService.AuthResult result = authService.activateAccount(token);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(testUser.isEnabled());
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void activateAccount_invalidToken_throwsException() {
+        // Arrange
+        String token = "invalid-token";
+        when(userRepository.findByActivationToken(token)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> authService.activateAccount(token));
+        assertEquals("Invalid activation token", exception.getMessage());
+    }
+
+    @Test
+    void activateAccount_expiredToken_throwsException() {
+        // Arrange
+        String token = UUID.randomUUID().toString();
+        testUser.setActivationToken(token);
+        testUser.setActivationTokenExpiry(Instant.now().minusSeconds(3600)); // Expired
+
+        when(userRepository.findByActivationToken(token)).thenReturn(Optional.of(testUser));
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> authService.activateAccount(token));
+        assertEquals("Activation token expired", exception.getMessage());
+    }
+
+    @Test
+    void login_userNotFound_throwsException() {
+        // Arrange
+        LoginRequest request = new LoginRequest("notfound@example.com", "password");
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> authService.login(request));
+        assertEquals("User not found", exception.getMessage());
+    }
+
+    @Test
+    void login_accountNotActivated_throwsException() {
+        // Arrange
+        LoginRequest request = new LoginRequest("test@example.com", "password");
+        testUser.setEnabled(false);
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(testUser));
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> authService.login(request));
+        assertTrue(exception.getMessage().contains("not activated"));
+    }
+
+    @Test
+    void loginWithGoogle_success_newUser() throws Exception {
+        // Arrange
+        GoogleLoginRequest request = new GoogleLoginRequest("google-credential");
+        GoogleIdToken idToken = mock(GoogleIdToken.class);
+        GoogleIdToken.Payload payload = mock(GoogleIdToken.Payload.class);
+
+        when(googleIdTokenVerifier.verify("google-credential")).thenReturn(idToken);
+        when(idToken.getPayload()).thenReturn(payload);
+        when(payload.getEmail()).thenReturn("google@example.com");
+        when(payload.get("name")).thenReturn("Google User");
+        when(payload.get("picture")).thenReturn("https://example.com/pic.jpg");
+
+        when(userRepository.findByEmail("google@example.com")).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            User u = invocation.getArgument(0);
+            u.setId(UUID.randomUUID());
+            return u;
+        });
+        when(jwtService.generateAccessToken(any(User.class))).thenReturn("access-token");
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setToken("refresh-token");
+        when(refreshTokenService.create(any(User.class))).thenReturn(refreshToken);
+
+        // Act
+        AuthService.AuthResult result = authService.loginWithGoogle(request);
+
+        // Assert
+        assertNotNull(result);
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void loginWithGoogle_success_existingUser() throws Exception {
+        // Arrange
+        GoogleLoginRequest request = new GoogleLoginRequest("google-credential");
+        GoogleIdToken idToken = mock(GoogleIdToken.class);
+        GoogleIdToken.Payload payload = mock(GoogleIdToken.Payload.class);
+
+        when(googleIdTokenVerifier.verify("google-credential")).thenReturn(idToken);
+        when(idToken.getPayload()).thenReturn(payload);
+        when(payload.getEmail()).thenReturn("google@example.com");
+
+        testUser.setAuthProvider(AuthProvider.GOOGLE);
+        when(userRepository.findByEmail("google@example.com")).thenReturn(Optional.of(testUser));
+        when(jwtService.generateAccessToken(any(User.class))).thenReturn("access-token");
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setToken("refresh-token");
+        when(refreshTokenService.create(any(User.class))).thenReturn(refreshToken);
+
+        // Act
+        AuthService.AuthResult result = authService.loginWithGoogle(request);
+
+        // Assert
+        assertNotNull(result);
+    }
+
+    @Test
+    void loginWithGoogle_invalidCredential_throwsException() throws Exception {
+        // Arrange
+        GoogleLoginRequest request = new GoogleLoginRequest("invalid-credential");
+        when(googleIdTokenVerifier.verify("invalid-credential")).thenReturn(null);
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> authService.loginWithGoogle(request));
+        assertEquals("Invalid Google credential", exception.getMessage());
+    }
+
+    @Test
+    void refresh_success() {
+        // Arrange
+        String refreshTokenValue = "refresh-token";
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setToken(refreshTokenValue);
+        refreshToken.setUser(testUser);
+
+        when(refreshTokenService.validateToken(refreshTokenValue)).thenReturn(refreshToken);
+        when(jwtService.generateAccessToken(any(User.class))).thenReturn("new-access-token");
+        RefreshToken newRefreshToken = new RefreshToken();
+        newRefreshToken.setToken("new-refresh-token");
+        when(refreshTokenService.create(any(User.class))).thenReturn(newRefreshToken);
+
+        // Act
+        AuthService.AuthResult result = authService.refresh(refreshTokenValue);
+
+        // Assert
+        assertNotNull(result);
+        verify(refreshTokenService).revokeAll(testUser);
+    }
+
+    @Test
+    void refresh_accountNotActivated_throwsException() {
+        // Arrange
+        String refreshTokenValue = "refresh-token";
+        testUser.setEnabled(false);
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setToken(refreshTokenValue);
+        refreshToken.setUser(testUser);
+
+        when(refreshTokenService.validateToken(refreshTokenValue)).thenReturn(refreshToken);
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> authService.refresh(refreshTokenValue));
+        assertEquals("Account not activated.", exception.getMessage());
+    }
+
+    @Test
+    void logout_success() {
+        // Arrange
+        doNothing().when(refreshTokenService).revokeAll(testUser);
+
+        // Act
+        assertDoesNotThrow(() -> authService.logout(testUser));
+
+        // Assert
+        verify(refreshTokenService).revokeAll(testUser);
+    }
+
+    @Test
+    void initiatePasswordReset_success() {
+        // Arrange
+        String email = "test@example.com";
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(testUser));
+        when(passwordResetTokenRepository.findByUser(testUser)).thenReturn(Optional.empty());
+        when(passwordResetTokenRepository.save(any(PasswordResetToken.class))).thenAnswer(invocation -> {
+            PasswordResetToken token = invocation.getArgument(0);
+            return token;
+        });
+        doNothing().when(emailService).sendPasswordResetEmail(anyString(), anyString(), anyString());
+
+        // Act
+        assertDoesNotThrow(() -> authService.initiatePasswordReset(email));
+
+        // Assert
+        verify(passwordResetTokenRepository).save(any(PasswordResetToken.class));
+        verify(emailService).sendPasswordResetEmail(eq(email), anyString(), anyString());
+    }
+
+    @Test
+    void initiatePasswordReset_userNotFound_throwsException() {
+        // Arrange
+        String email = "notfound@example.com";
+        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> authService.initiatePasswordReset(email));
+        assertTrue(exception.getMessage().contains("User not found"));
+    }
+
+    @Test
+    void resetPassword_success() {
+        // Arrange
+        String token = UUID.randomUUID().toString();
+        String newPassword = "newPassword123";
+        PasswordResetToken resetToken = PasswordResetToken.builder()
+                .token(token)
+                .user(testUser)
+                .expiryDate(LocalDateTime.now().plusMinutes(15))
+                .build();
+
+        when(passwordResetTokenRepository.findByToken(token)).thenReturn(Optional.of(resetToken));
+        when(passwordEncoder.encode(newPassword)).thenReturn("encoded-new-password");
+        when(userRepository.save(any(User.class))).thenReturn(testUser);
+        doNothing().when(passwordResetTokenRepository).delete(resetToken);
+
+        // Act
+        assertDoesNotThrow(() -> authService.resetPassword(token, newPassword));
+
+        // Assert
+        verify(passwordEncoder).encode(newPassword);
+        verify(userRepository).save(any(User.class));
+        verify(passwordResetTokenRepository).delete(resetToken);
+    }
+
+    @Test
+    void resetPassword_invalidToken_throwsException() {
+        // Arrange
+        String token = "invalid-token";
+        when(passwordResetTokenRepository.findByToken(token)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> authService.resetPassword(token, "newPassword"));
+        assertTrue(exception.getMessage().contains("Invalid or expired"));
+    }
+
+    @Test
+    void resetPassword_expiredToken_throwsException() {
+        // Arrange
+        String token = UUID.randomUUID().toString();
+        PasswordResetToken resetToken = PasswordResetToken.builder()
+                .token(token)
+                .user(testUser)
+                .expiryDate(LocalDateTime.now().minusMinutes(1)) // Expired
+                .build();
+
+        when(passwordResetTokenRepository.findByToken(token)).thenReturn(Optional.of(resetToken));
+        doNothing().when(passwordResetTokenRepository).delete(resetToken);
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> authService.resetPassword(token, "newPassword"));
+        assertEquals("Token expired", exception.getMessage());
+        verify(passwordResetTokenRepository).delete(resetToken);
     }
 }

--- a/backend/src/test/java/com/awad/ticketbooking/modules/auth/service/UserServiceTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/auth/service/UserServiceTest.java
@@ -1,0 +1,195 @@
+package com.awad.ticketbooking.modules.auth.service;
+
+import com.awad.ticketbooking.modules.auth.dto.ChangePasswordRequest;
+import com.awad.ticketbooking.modules.auth.dto.UpdateAvatarRequest;
+import com.awad.ticketbooking.modules.auth.dto.UpdateProfileRequest;
+import com.awad.ticketbooking.modules.auth.entity.AuthProvider;
+import com.awad.ticketbooking.modules.auth.entity.User;
+import com.awad.ticketbooking.modules.auth.entity.UserRole;
+import com.awad.ticketbooking.modules.auth.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class UserServiceTest {
+
+    @InjectMocks
+    private UserService userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .email("test@example.com")
+                .fullName("Test User")
+                .phone("0123456789")
+                .passwordHash("encoded-password")
+                .authProvider(AuthProvider.LOCAL)
+                .build();
+        testUser.setId(UUID.randomUUID());
+        testUser.setRole(UserRole.PASSENGER);
+    }
+
+    @Test
+    void updateProfile_success() {
+        // Arrange
+        UpdateProfileRequest request = new UpdateProfileRequest("Updated Name", "0987654321");
+        when(userRepository.findByPhone("0987654321")).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+        // Act
+        User result = userService.updateProfile(testUser, request);
+
+        // Assert
+        assertNotNull(result);
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void updateProfile_samePhone_success() {
+        // Arrange
+        UpdateProfileRequest request = new UpdateProfileRequest("Updated Name", "0123456789");
+        when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+        // Act
+        User result = userService.updateProfile(testUser, request);
+
+        // Assert
+        assertNotNull(result);
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void updateProfile_phoneAlreadyExists_throwsException() {
+        // Arrange
+        User otherUser = User.builder()
+                .email("other@example.com")
+                .fullName("Other User")
+                .phone("0987654321")
+                .build();
+        otherUser.setId(UUID.randomUUID());
+
+        UpdateProfileRequest request = new UpdateProfileRequest("Updated Name", "0987654321");
+        when(userRepository.findByPhone("0987654321")).thenReturn(Optional.of(otherUser));
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> userService.updateProfile(testUser, request));
+        assertEquals("Phone number already in use", exception.getMessage());
+    }
+
+    @Test
+    void changePassword_success() {
+        // Arrange
+        ChangePasswordRequest request = new ChangePasswordRequest("oldPassword", "newPassword");
+        when(passwordEncoder.matches("oldPassword", "encoded-password")).thenReturn(true);
+        when(passwordEncoder.matches("newPassword", "encoded-password")).thenReturn(false);
+        when(passwordEncoder.encode("newPassword")).thenReturn("new-encoded-password");
+        when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+        // Act
+        userService.changePassword(testUser, request);
+
+        // Assert
+        verify(userRepository).save(any(User.class));
+        verify(passwordEncoder).encode("newPassword");
+    }
+
+    @Test
+    void changePassword_oauthUser_throwsException() {
+        // Arrange
+        testUser.setAuthProvider(AuthProvider.GOOGLE);
+        ChangePasswordRequest request = new ChangePasswordRequest("oldPassword", "newPassword");
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> userService.changePassword(testUser, request));
+        assertEquals("Password cannot be changed for OAuth accounts", exception.getMessage());
+    }
+
+    @Test
+    void changePassword_wrongOldPassword_throwsException() {
+        // Arrange
+        ChangePasswordRequest request = new ChangePasswordRequest("wrongPassword", "newPassword");
+        when(passwordEncoder.matches("wrongPassword", "encoded-password")).thenReturn(false);
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> userService.changePassword(testUser, request));
+        assertEquals("Old password is incorrect", exception.getMessage());
+    }
+
+    @Test
+    void changePassword_sameAsOld_throwsException() {
+        // Arrange
+        ChangePasswordRequest request = new ChangePasswordRequest("oldPassword", "oldPassword");
+        when(passwordEncoder.matches("oldPassword", "encoded-password")).thenReturn(true);
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> userService.changePassword(testUser, request));
+        assertEquals("New password must be different from old password", exception.getMessage());
+    }
+
+    @Test
+    void changePassword_nullPasswordHash_throwsException() {
+        // Arrange
+        testUser.setPasswordHash(null);
+        ChangePasswordRequest request = new ChangePasswordRequest("oldPassword", "newPassword");
+
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> userService.changePassword(testUser, request));
+        assertEquals("Old password is incorrect", exception.getMessage());
+    }
+
+    @Test
+    void updateAvatar_success() {
+        // Arrange
+        UpdateAvatarRequest request = new UpdateAvatarRequest("https://example.com/avatar.jpg");
+        when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+        // Act
+        User result = userService.updateAvatar(testUser, request);
+
+        // Assert
+        assertNotNull(result);
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void updateAvatar_nullUrl_success() {
+        // Arrange
+        UpdateAvatarRequest request = new UpdateAvatarRequest(null);
+        when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+        // Act
+        User result = userService.updateAvatar(testUser, request);
+
+        // Assert
+        assertNotNull(result);
+        verify(userRepository).save(any(User.class));
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/booking/controller/BookingControllerTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/booking/controller/BookingControllerTest.java
@@ -1,0 +1,282 @@
+package com.awad.ticketbooking.modules.booking.controller;
+
+import com.awad.ticketbooking.common.config.security.ApplicationUserDetails;
+import com.awad.ticketbooking.common.enums.BookingStatus;
+import com.awad.ticketbooking.modules.auth.entity.User;
+import com.awad.ticketbooking.modules.auth.entity.UserRole;
+import com.awad.ticketbooking.modules.booking.dto.BookingLookupRequest;
+import com.awad.ticketbooking.modules.booking.dto.BookingResponse;
+import com.awad.ticketbooking.modules.booking.dto.CreateBookingRequest;
+import com.awad.ticketbooking.modules.booking.dto.RefundCalculation;
+import com.awad.ticketbooking.modules.booking.dto.TicketRequest;
+import com.awad.ticketbooking.modules.booking.dto.UpdateBookingRequest;
+import com.awad.ticketbooking.modules.booking.service.BookingService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class BookingControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private BookingService bookingService;
+
+    @InjectMocks
+    private BookingController bookingController;
+
+    private ObjectMapper objectMapper;
+    private BookingResponse mockBookingResponse;
+    private User testUser;
+    private ApplicationUserDetails userDetails;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(bookingController).build();
+        objectMapper = new ObjectMapper();
+
+        testUser = new User();
+        testUser.setId(UUID.randomUUID());
+        testUser.setEmail("test@example.com");
+        testUser.setRole(UserRole.PASSENGER);
+        userDetails = new ApplicationUserDetails(testUser);
+
+        mockBookingResponse = BookingResponse.builder()
+                .id(UUID.randomUUID())
+                .code("BK-12345")
+                .status(BookingStatus.PENDING)
+                .totalPrice(new BigDecimal("200000"))
+                .passengerName("Test Passenger")
+                .passengerPhone("0123456789")
+                .createdAt(Instant.now())
+                .build();
+    }
+
+    @Test
+    void createBooking_success() throws Exception {
+        // Arrange
+        CreateBookingRequest request = new CreateBookingRequest();
+        request.setTripId(UUID.randomUUID());
+        request.setPassengerName("Test Passenger");
+        request.setPassengerPhone("0123456789");
+        request.setPassengerEmail("test@example.com");
+        TicketRequest ticket = new TicketRequest();
+        ticket.setSeatCode("A01");
+        ticket.setPassengerName("Test Passenger");
+        ticket.setPassengerPhone("0123456789");
+        ticket.setPrice(new BigDecimal("200000"));
+        request.setTickets(Arrays.asList(ticket));
+        request.setTotalPrice(new BigDecimal("200000"));
+        when(bookingService.createBooking(any(CreateBookingRequest.class))).thenReturn(mockBookingResponse);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/bookings")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("BK-12345"));
+
+        verify(bookingService).createBooking(any(CreateBookingRequest.class));
+    }
+
+    @Test
+    void lookupBooking_success() throws Exception {
+        // Arrange
+        BookingLookupRequest request = new BookingLookupRequest();
+        request.setCode("BK-12345");
+        request.setEmail("test@example.com");
+        when(bookingService.lookupBooking(anyString(), anyString())).thenReturn(mockBookingResponse);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/bookings/lookup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("BK-12345"));
+
+        verify(bookingService).lookupBooking("BK-12345", "test@example.com");
+    }
+
+    @Test
+    void getBookingById_success() throws Exception {
+        // Arrange
+        UUID bookingId = UUID.randomUUID();
+        when(bookingService.getBookingById(bookingId)).thenReturn(mockBookingResponse);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/bookings/{id}", bookingId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("BK-12345"));
+
+        verify(bookingService).getBookingById(bookingId);
+    }
+
+    // Note: getUserBookings tests require Spring Security context and Pageable binding
+    // which don't work properly in standalone MockMvc setup.
+    // These are tested in integration tests instead.
+
+    @Test
+    void getBookedSeatsForTrip_success() throws Exception {
+        // Arrange
+        UUID tripId = UUID.randomUUID();
+        List<String> bookedSeats = Arrays.asList("A01", "A02", "B01");
+        when(bookingService.getBookedSeatsForTrip(tripId)).thenReturn(bookedSeats);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/bookings/trip/{tripId}/seats", tripId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0]").value("A01"))
+                .andExpect(jsonPath("$[1]").value("A02"));
+
+        verify(bookingService).getBookedSeatsForTrip(tripId);
+    }
+
+    @Test
+    void confirmBooking_success() throws Exception {
+        // Arrange
+        UUID bookingId = UUID.randomUUID();
+        BookingResponse confirmedResponse = BookingResponse.builder()
+                .id(bookingId)
+                .code("BK-12345")
+                .status(BookingStatus.CONFIRMED)
+                .build();
+        when(bookingService.confirmBooking(bookingId)).thenReturn(confirmedResponse);
+
+        // Act & Assert
+        mockMvc.perform(put("/api/bookings/{id}/confirm", bookingId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("CONFIRMED"));
+
+        verify(bookingService).confirmBooking(bookingId);
+    }
+
+    @Test
+    void updateBooking_success() throws Exception {
+        // Arrange
+        UUID bookingId = UUID.randomUUID();
+        UpdateBookingRequest request = new UpdateBookingRequest();
+        request.setPassengerName("Updated Name");
+        request.setPassengerPhone("0987654321");
+        when(bookingService.updateBooking(eq(bookingId), any(UpdateBookingRequest.class)))
+                .thenReturn(mockBookingResponse);
+
+        // Act & Assert
+        mockMvc.perform(put("/api/bookings/{id}", bookingId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        verify(bookingService).updateBooking(eq(bookingId), any(UpdateBookingRequest.class));
+    }
+
+    @Test
+    void cancelBooking_success() throws Exception {
+        // Arrange
+        UUID bookingId = UUID.randomUUID();
+        BookingResponse cancelledResponse = BookingResponse.builder()
+                .id(bookingId)
+                .code("BK-12345")
+                .status(BookingStatus.CANCELLED)
+                .build();
+        when(bookingService.cancelBooking(bookingId)).thenReturn(cancelledResponse);
+
+        // Act & Assert
+        mockMvc.perform(put("/api/bookings/{id}/cancel", bookingId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("CANCELLED"));
+
+        verify(bookingService).cancelBooking(bookingId);
+    }
+
+    @Test
+    void getRefundEstimate_success() throws Exception {
+        // Arrange
+        UUID bookingId = UUID.randomUUID();
+        RefundCalculation refundCalc = RefundCalculation.builder()
+                .refundAmount(new BigDecimal("150000"))
+                .refundPercentage(75.0)
+                .policyDescription("Partial refund available")
+                .isRefundable(true)
+                .build();
+        when(bookingService.calculateRefund(bookingId)).thenReturn(refundCalc);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/bookings/{id}/refund-estimate", bookingId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.refundAmount").value(150000));
+
+        verify(bookingService).calculateRefund(bookingId);
+    }
+
+    @Test
+    void checkInPassenger_success() throws Exception {
+        // Arrange
+        UUID ticketId = UUID.randomUUID();
+        when(bookingService.checkInPassenger(ticketId)).thenReturn(mockBookingResponse);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/bookings/tickets/{id}/check-in", ticketId))
+                .andExpect(status().isOk());
+
+        verify(bookingService).checkInPassenger(ticketId);
+    }
+
+    @Test
+    void checkInBooking_success() throws Exception {
+        // Arrange
+        String bookingCode = "BK-12345";
+        when(bookingService.checkInBooking(bookingCode)).thenReturn(mockBookingResponse);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/bookings/{code}/check-in-booking", bookingCode))
+                .andExpect(status().isOk());
+
+        verify(bookingService).checkInBooking(bookingCode);
+    }
+
+    // Note: getAdminBookings test requires Spring Security context and Pageable binding
+    // which don't work properly in standalone MockMvc setup.
+    // This is tested in integration tests instead.
+
+    @Test
+    void refundBooking_success() throws Exception {
+        // Arrange
+        UUID bookingId = UUID.randomUUID();
+        BookingResponse refundedResponse = BookingResponse.builder()
+                .id(bookingId)
+                .code("BK-12345")
+                .status(BookingStatus.REFUNDED)
+                .build();
+        when(bookingService.refundBooking(bookingId)).thenReturn(refundedResponse);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/bookings/{id}/refund", bookingId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("REFUNDED"));
+
+        verify(bookingService).refundBooking(bookingId);
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/booking/controller/SeatControllerTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/booking/controller/SeatControllerTest.java
@@ -1,0 +1,213 @@
+package com.awad.ticketbooking.modules.booking.controller;
+
+import com.awad.ticketbooking.common.config.security.ApplicationUserDetails;
+import com.awad.ticketbooking.common.enums.BookingStatus;
+import com.awad.ticketbooking.modules.auth.entity.User;
+import com.awad.ticketbooking.modules.auth.entity.UserRole;
+import com.awad.ticketbooking.modules.booking.dto.LockSeatRequest;
+import com.awad.ticketbooking.modules.booking.repository.BookingRepository;
+import com.awad.ticketbooking.modules.booking.service.SeatLockService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class SeatControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private SeatLockService seatLockService;
+
+    @Mock
+    private BookingRepository bookingRepository;
+
+    @InjectMocks
+    private SeatController seatController;
+
+    private ObjectMapper objectMapper;
+    private User testUser;
+    private ApplicationUserDetails userDetails;
+
+    @BeforeEach
+    void setUp() {
+        AuthenticationPrincipalArgumentResolver authResolver = new AuthenticationPrincipalArgumentResolver();
+        mockMvc = MockMvcBuilders.standaloneSetup(seatController)
+                .setCustomArgumentResolvers(authResolver)
+                .build();
+        objectMapper = new ObjectMapper();
+
+        testUser = new User();
+        testUser.setId(UUID.randomUUID());
+        testUser.setEmail("test@example.com");
+        testUser.setRole(UserRole.PASSENGER);
+        userDetails = new ApplicationUserDetails(testUser);
+    }
+    
+    private void setupSecurityContext() {
+        SecurityContext context = new SecurityContextImpl();
+        Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        context.setAuthentication(auth);
+        SecurityContextHolder.setContext(context);
+    }
+    
+    private void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void lockSeat_success() throws Exception {
+        try {
+            setupSecurityContext();
+            // Arrange
+            LockSeatRequest request = new LockSeatRequest();
+            request.setTripId(UUID.randomUUID());
+            request.setSeatCode("A01");
+            when(bookingRepository.existsByTripIdAndTicketsSeatCodeAndStatusNot(any(), anyString(), any()))
+                    .thenReturn(false);
+            when(seatLockService.lockSeat(any(), anyString(), any())).thenReturn(true);
+
+            // Act & Assert
+            mockMvc.perform(post("/api/bookings/seats/lock")
+                            .with(SecurityMockMvcRequestPostProcessors.user(userDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk());
+
+            verify(seatLockService).lockSeat(any(), anyString(), any());
+        } finally {
+            clearSecurityContext();
+        }
+    }
+
+    @Test
+    void lockSeat_alreadyBooked() throws Exception {
+        try {
+            setupSecurityContext();
+            // Arrange
+            LockSeatRequest request = new LockSeatRequest();
+            request.setTripId(UUID.randomUUID());
+            request.setSeatCode("A01");
+            when(bookingRepository.existsByTripIdAndTicketsSeatCodeAndStatusNot(any(), anyString(), any()))
+                    .thenReturn(true);
+
+            // Act & Assert
+            mockMvc.perform(post("/api/bookings/seats/lock")
+                            .with(SecurityMockMvcRequestPostProcessors.user(userDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+
+            verify(seatLockService, never()).lockSeat(any(), anyString(), any());
+        } finally {
+            clearSecurityContext();
+        }
+    }
+
+    @Test
+    void lockSeat_alreadyLocked() throws Exception {
+        try {
+            setupSecurityContext();
+            // Arrange
+            LockSeatRequest request = new LockSeatRequest();
+            request.setTripId(UUID.randomUUID());
+            request.setSeatCode("A01");
+            when(bookingRepository.existsByTripIdAndTicketsSeatCodeAndStatusNot(any(), anyString(), any()))
+                    .thenReturn(false);
+            when(seatLockService.lockSeat(any(), anyString(), any())).thenReturn(false);
+
+            // Act & Assert
+            mockMvc.perform(post("/api/bookings/seats/lock")
+                            .with(SecurityMockMvcRequestPostProcessors.user(userDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isConflict());
+
+            verify(seatLockService).lockSeat(any(), anyString(), any());
+        } finally {
+            clearSecurityContext();
+        }
+    }
+
+    @Test
+    void lockSeat_withGuestId() throws Exception {
+        // Arrange
+        LockSeatRequest request = new LockSeatRequest();
+        request.setTripId(UUID.randomUUID());
+        request.setSeatCode("A01");
+        request.setGuestId(UUID.randomUUID().toString());
+        when(bookingRepository.existsByTripIdAndTicketsSeatCodeAndStatusNot(any(), anyString(), any()))
+                .thenReturn(false);
+        when(seatLockService.lockSeat(any(), anyString(), any())).thenReturn(true);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/bookings/seats/lock")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        verify(seatLockService).lockSeat(any(), anyString(), any());
+    }
+
+    @Test
+    void unlockSeat_success() throws Exception {
+        try {
+            setupSecurityContext();
+            // Arrange
+            LockSeatRequest request = new LockSeatRequest();
+            request.setTripId(UUID.randomUUID());
+            request.setSeatCode("A01");
+            doNothing().when(seatLockService).unlockSeat(any(), anyString(), any());
+
+            // Act & Assert
+            mockMvc.perform(post("/api/bookings/seats/unlock")
+                            .with(SecurityMockMvcRequestPostProcessors.user(userDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk());
+
+            verify(seatLockService).unlockSeat(any(), anyString(), any());
+        } finally {
+            clearSecurityContext();
+        }
+    }
+
+    @Test
+    void getSeatStatus_success() throws Exception {
+        // Arrange
+        UUID tripId = UUID.randomUUID();
+        Map<String, UUID> lockedSeats = new HashMap<>();
+        lockedSeats.put("A01", UUID.randomUUID());
+        when(bookingRepository.findAllByTripIdAndStatusNot(any(), any())).thenReturn(java.util.Collections.emptyList());
+        when(seatLockService.getLockedSeats(tripId)).thenReturn(lockedSeats);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/bookings/seats/{tripId}", tripId))
+                .andExpect(status().isOk());
+
+        verify(seatLockService).getLockedSeats(tripId);
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/booking/service/BookingServiceTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/booking/service/BookingServiceTest.java
@@ -1,0 +1,742 @@
+package com.awad.ticketbooking.modules.booking.service;
+
+import com.awad.ticketbooking.common.enums.BookingStatus;
+import com.awad.ticketbooking.common.service.EmailService;
+import com.awad.ticketbooking.modules.auth.entity.User;
+import com.awad.ticketbooking.modules.auth.repository.UserRepository;
+import com.awad.ticketbooking.modules.booking.dto.BookingResponse;
+import com.awad.ticketbooking.modules.booking.dto.CreateBookingRequest;
+import com.awad.ticketbooking.modules.booking.dto.RefundCalculation;
+import com.awad.ticketbooking.modules.booking.dto.TicketRequest;
+import com.awad.ticketbooking.modules.booking.dto.UpdateBookingRequest;
+import com.awad.ticketbooking.modules.booking.entity.Booking;
+import com.awad.ticketbooking.modules.booking.entity.Ticket;
+import com.awad.ticketbooking.modules.booking.repository.BookingRepository;
+import com.awad.ticketbooking.modules.booking.repository.TicketRepository;
+import com.awad.ticketbooking.modules.catalog.entity.Bus;
+import com.awad.ticketbooking.modules.catalog.entity.BusLayout;
+import com.awad.ticketbooking.modules.catalog.entity.Operator;
+import com.awad.ticketbooking.modules.catalog.entity.Route;
+import com.awad.ticketbooking.modules.catalog.entity.Station;
+import com.awad.ticketbooking.modules.catalog.repository.StationRepository;
+import com.awad.ticketbooking.modules.trip.entity.Trip;
+import com.awad.ticketbooking.modules.trip.repository.TripRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import org.mockito.ArgumentMatchers;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class BookingServiceTest {
+
+    @InjectMocks
+    private BookingService bookingService;
+
+    @Mock
+    private BookingRepository bookingRepository;
+
+    @Mock
+    private TripRepository tripRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private TicketRepository ticketRepository;
+
+    @Mock
+    private StationRepository stationRepository;
+
+    @Mock
+    private EmailService emailService;
+
+    @Mock
+    private SeatLockService seatLockService;
+
+    private Trip testTrip;
+    private User testUser;
+    private Booking testBooking;
+    private Station originStation;
+    private Station destinationStation;
+
+    @BeforeEach
+    void setUp() {
+        // Setup origin station
+        originStation = new Station();
+        originStation.setId(UUID.randomUUID());
+        originStation.setName("Hanoi Station");
+        originStation.setCity("Hanoi");
+        originStation.setAddress("123 Main St");
+
+        // Setup destination station
+        destinationStation = new Station();
+        destinationStation.setId(UUID.randomUUID());
+        destinationStation.setName("Saigon Station");
+        destinationStation.setCity("Saigon");
+        destinationStation.setAddress("456 Main St");
+
+        // Setup route
+        Route route = new Route();
+        route.setId(UUID.randomUUID());
+        route.setOriginStation(originStation);
+        route.setDestinationStation(destinationStation);
+        route.setDurationMinutes(360);
+
+        // Setup operator
+        Operator operator = new Operator();
+        operator.setId(UUID.randomUUID());
+        operator.setName("Test Operator");
+
+        // Setup bus layout
+        BusLayout busLayout = new BusLayout();
+        busLayout.setId(UUID.randomUUID());
+        busLayout.setTotalSeats(40);
+
+        // Setup bus
+        Bus bus = new Bus();
+        bus.setId(UUID.randomUUID());
+        bus.setPlateNumber("29A-12345");
+        bus.setOperator(operator);
+        bus.setBusLayout(busLayout);
+        bus.setAmenities(Collections.singletonList("wifi"));
+
+        // Setup trip
+        testTrip = new Trip();
+        testTrip.setId(UUID.randomUUID());
+        testTrip.setRoute(route);
+        testTrip.setBus(bus);
+        testTrip.setDepartureTime(Instant.now().plus(2, ChronoUnit.DAYS));
+        testTrip.setArrivalTime(Instant.now().plus(2, ChronoUnit.DAYS).plus(6, ChronoUnit.HOURS));
+        testTrip.setTripStops(new ArrayList<>());
+
+        // Setup user
+        testUser = User.builder()
+                .email("test@example.com")
+                .fullName("Test User")
+                .build();
+        testUser.setId(UUID.randomUUID());
+
+        // Setup booking
+        testBooking = new Booking();
+        testBooking.setId(UUID.randomUUID());
+        testBooking.setCode("BK-ABC123");
+        testBooking.setTrip(testTrip);
+        testBooking.setUser(testUser);
+        testBooking.setPassengerName("Test Passenger");
+        testBooking.setPassengerPhone("0123456789");
+        testBooking.setPassengerEmail("test@example.com");
+        testBooking.setStatus(BookingStatus.PENDING);
+        testBooking.setTotalPrice(new BigDecimal("200000"));
+        testBooking.setPickupStation(originStation);
+        testBooking.setDropoffStation(destinationStation);
+
+        Ticket ticket = new Ticket();
+        ticket.setId(UUID.randomUUID());
+        ticket.setBooking(testBooking);
+        ticket.setSeatCode("A1");
+        ticket.setPassengerName("Test Passenger");
+        ticket.setPassengerPhone("0123456789");
+        ticket.setPrice(new BigDecimal("200000"));
+        testBooking.setTickets(new ArrayList<>(Collections.singletonList(ticket)));
+    }
+
+    @Test
+    void createBooking_success() {
+        // Arrange
+        CreateBookingRequest request = new CreateBookingRequest();
+        request.setTripId(testTrip.getId());
+        request.setUserId(testUser.getId());
+        request.setPassengerName("Test Passenger");
+        request.setPassengerPhone("0123456789");
+        request.setPassengerEmail("test@example.com");
+        request.setTotalPrice(new BigDecimal("200000"));
+
+        TicketRequest ticketRequest = new TicketRequest();
+        ticketRequest.setSeatCode("A1");
+        ticketRequest.setPassengerName("Test Passenger");
+        ticketRequest.setPassengerPhone("0123456789");
+        ticketRequest.setPrice(new BigDecimal("200000"));
+        request.setTickets(Collections.singletonList(ticketRequest));
+
+        when(tripRepository.findById(request.getTripId())).thenReturn(Optional.of(testTrip));
+        when(userRepository.findById(request.getUserId())).thenReturn(Optional.of(testUser));
+        when(ticketRepository.findBookedSeatCodesByTripId(request.getTripId())).thenReturn(Collections.emptyList());
+        when(ticketRepository.findByBookingTripIdAndSeatCodeIn(any(), anyList())).thenReturn(Collections.emptyList());
+        when(bookingRepository.findByCode(anyString())).thenReturn(Optional.empty());
+        when(bookingRepository.save(any(Booking.class))).thenAnswer(invocation -> {
+            Booking b = invocation.getArgument(0);
+            b.setId(UUID.randomUUID());
+            return b;
+        });
+
+        // Act
+        BookingResponse response = bookingService.createBooking(request);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals("Test Passenger", response.getPassengerName());
+        verify(bookingRepository).save(any(Booking.class));
+        verify(seatLockService).markSeatsAsBooked(eq(testTrip.getId()), anyList());
+    }
+
+    @Test
+    void createBooking_tripNotFound_throwsException() {
+        // Arrange
+        CreateBookingRequest request = new CreateBookingRequest();
+        request.setTripId(UUID.randomUUID());
+
+        when(tripRepository.findById(request.getTripId())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> bookingService.createBooking(request));
+        assertEquals("Trip not found", exception.getMessage());
+    }
+
+    @Test
+    void createBooking_seatAlreadyBooked_throwsException() {
+        // Arrange
+        CreateBookingRequest request = new CreateBookingRequest();
+        request.setTripId(testTrip.getId());
+        request.setPassengerName("Test Passenger");
+        request.setPassengerPhone("0123456789");
+        request.setTotalPrice(new BigDecimal("200000"));
+
+        TicketRequest ticketRequest = new TicketRequest();
+        ticketRequest.setSeatCode("A1");
+        ticketRequest.setPassengerName("Test Passenger");
+        ticketRequest.setPassengerPhone("0123456789");
+        ticketRequest.setPrice(new BigDecimal("200000"));
+        request.setTickets(Collections.singletonList(ticketRequest));
+
+        // Create a conflicting ticket from another user's CONFIRMED booking
+        Booking otherBooking = new Booking();
+        otherBooking.setId(UUID.randomUUID());
+        otherBooking.setStatus(BookingStatus.CONFIRMED);
+        otherBooking.setUser(null); // Different user
+
+        Ticket conflictingTicket = new Ticket();
+        conflictingTicket.setId(UUID.randomUUID());
+        conflictingTicket.setSeatCode("A1");
+        conflictingTicket.setBooking(otherBooking);
+
+        when(tripRepository.findById(request.getTripId())).thenReturn(Optional.of(testTrip));
+        when(ticketRepository.findBookedSeatCodesByTripId(request.getTripId())).thenReturn(Collections.singletonList("A1"));
+        when(ticketRepository.findByBookingTripIdAndSeatCodeIn(any(), anyList()))
+                .thenReturn(Collections.singletonList(conflictingTicket));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> bookingService.createBooking(request));
+        assertTrue(exception.getMessage().contains("already booked"));
+    }
+
+    @Test
+    void confirmBooking_success() {
+        // Arrange
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+        when(bookingRepository.save(any(Booking.class))).thenReturn(testBooking);
+        when(bookingRepository.findByIdWithFullDetails(testBooking.getId())).thenReturn(Optional.of(testBooking));
+
+        // Act
+        BookingResponse response = bookingService.confirmBooking(testBooking.getId());
+
+        // Assert
+        assertNotNull(response);
+        verify(bookingRepository).save(any(Booking.class));
+        verify(emailService).sendBookingConfirmationEmail(any(Booking.class), anyString());
+    }
+
+    @Test
+    void confirmBooking_notPending_throwsException() {
+        // Arrange
+        testBooking.setStatus(BookingStatus.CONFIRMED);
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> bookingService.confirmBooking(testBooking.getId()));
+        assertEquals("Only pending bookings can be confirmed", exception.getMessage());
+    }
+
+    @Test
+    void cancelBooking_success() {
+        // Arrange
+        testBooking.setStatus(BookingStatus.PENDING);
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+        when(bookingRepository.save(any(Booking.class))).thenReturn(testBooking);
+
+        // Act
+        BookingResponse response = bookingService.cancelBooking(testBooking.getId());
+
+        // Assert
+        assertNotNull(response);
+        verify(seatLockService).unlockSeatsForBooking(eq(testTrip.getId()), anyList());
+        verify(bookingRepository).save(any(Booking.class));
+    }
+
+    @Test
+    void cancelBooking_alreadyCancelled_throwsException() {
+        // Arrange
+        testBooking.setStatus(BookingStatus.CANCELLED);
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> bookingService.cancelBooking(testBooking.getId()));
+        assertEquals("Booking is already cancelled", exception.getMessage());
+    }
+
+    @Test
+    void refundBooking_success() {
+        // Arrange
+        testBooking.setStatus(BookingStatus.CONFIRMED);
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+        when(bookingRepository.save(any(Booking.class))).thenReturn(testBooking);
+
+        // Act
+        BookingResponse response = bookingService.refundBooking(testBooking.getId());
+
+        // Assert
+        assertNotNull(response);
+        verify(seatLockService).unlockSeatsForBooking(eq(testTrip.getId()), anyList());
+        verify(bookingRepository).save(any(Booking.class));
+    }
+
+    @Test
+    void refundBooking_alreadyRefunded_throwsException() {
+        // Arrange
+        testBooking.setStatus(BookingStatus.REFUNDED);
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> bookingService.refundBooking(testBooking.getId()));
+        assertEquals("Booking is already refunded", exception.getMessage());
+    }
+
+    @Test
+    void calculateRefund_refundableMoreThan24h() {
+        // Arrange - Trip is 2 days from now (more than 24h)
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+
+        // Act
+        RefundCalculation refund = bookingService.calculateRefund(testBooking.getId());
+
+        // Assert
+        assertNotNull(refund);
+        assertTrue(refund.isRefundable());
+        assertEquals(100.0, refund.getRefundPercentage());
+        assertEquals(testBooking.getTotalPrice(), refund.getRefundAmount());
+    }
+
+    @Test
+    void calculateRefund_notRefundableWithin24h() {
+        // Arrange - Trip departs in 12 hours (less than 24h)
+        testTrip.setDepartureTime(Instant.now().plus(12, ChronoUnit.HOURS));
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+
+        // Act
+        RefundCalculation refund = bookingService.calculateRefund(testBooking.getId());
+
+        // Assert
+        assertNotNull(refund);
+        assertFalse(refund.isRefundable());
+        assertEquals(0.0, refund.getRefundPercentage());
+        assertEquals(BigDecimal.ZERO, refund.getRefundAmount());
+    }
+
+    @Test
+    void lookupBooking_success() {
+        // Arrange
+        when(bookingRepository.findByCode("BK-ABC123")).thenReturn(Optional.of(testBooking));
+
+        // Act
+        BookingResponse response = bookingService.lookupBooking("BK-ABC123", "test@example.com");
+
+        // Assert
+        assertNotNull(response);
+        assertEquals("BK-ABC123", response.getCode());
+    }
+
+    @Test
+    void lookupBooking_emailMismatch_throwsException() {
+        // Arrange
+        when(bookingRepository.findByCode("BK-ABC123")).thenReturn(Optional.of(testBooking));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> bookingService.lookupBooking("BK-ABC123", "wrong@example.com"));
+        assertTrue(exception.getMessage().contains("not found or email does not match"));
+    }
+
+    @Test
+    void getBookingById_success() {
+        // Arrange
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+
+        // Act
+        BookingResponse response = bookingService.getBookingById(testBooking.getId());
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(testBooking.getId(), response.getId());
+    }
+
+    @Test
+    void getUserBookings_success() {
+        // Arrange
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Booking> page = new PageImpl<>(Collections.singletonList(testBooking));
+        when(bookingRepository.findByUserIdOrderByCreatedAtDesc(testUser.getId(), pageable)).thenReturn(page);
+
+        // Act
+        Page<BookingResponse> response = bookingService.getUserBookings(testUser.getId(), pageable);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(1, response.getTotalElements());
+    }
+
+    @Test
+    void checkInBooking_success() {
+        // Arrange
+        testBooking.setStatus(BookingStatus.CONFIRMED);
+        testBooking.getTickets().get(0).setBoarded(false);
+        when(bookingRepository.findByCode("BK-ABC123")).thenReturn(Optional.of(testBooking));
+        when(ticketRepository.saveAll(anyList())).thenReturn(testBooking.getTickets());
+
+        // Act
+        BookingResponse response = bookingService.checkInBooking("BK-ABC123");
+
+        // Assert
+        assertNotNull(response);
+        verify(ticketRepository).saveAll(anyList());
+    }
+
+    @Test
+    void checkInBooking_invalidStatus_throwsException() {
+        // Arrange
+        testBooking.setStatus(BookingStatus.PENDING);
+        when(bookingRepository.findByCode("BK-ABC123")).thenReturn(Optional.of(testBooking));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> bookingService.checkInBooking("BK-ABC123"));
+        assertTrue(exception.getMessage().contains("INVALID_STATUS"));
+    }
+
+    @Test
+    void checkInBooking_alreadyCheckedIn_throwsException() {
+        // Arrange
+        testBooking.setStatus(BookingStatus.CONFIRMED);
+        testBooking.getTickets().get(0).setBoarded(true);
+        when(bookingRepository.findByCode("BK-ABC123")).thenReturn(Optional.of(testBooking));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> bookingService.checkInBooking("BK-ABC123"));
+        assertTrue(exception.getMessage().contains("ALREADY_CHECKED_IN"));
+    }
+
+    @Test
+    void getBookedSeatsForTrip_success() {
+        // Arrange
+        List<String> bookedSeats = List.of("A1", "A2", "B1");
+        when(ticketRepository.findBookedSeatCodesByTripId(testTrip.getId())).thenReturn(bookedSeats);
+
+        // Act
+        List<String> result = bookingService.getBookedSeatsForTrip(testTrip.getId());
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(3, result.size());
+        assertTrue(result.contains("A1"));
+    }
+
+    @Test
+    void updateBooking_success() {
+        // Arrange
+        testBooking.setStatus(BookingStatus.PENDING);
+        UpdateBookingRequest request = new UpdateBookingRequest();
+        request.setPassengerName("Updated Passenger");
+        request.setPassengerPhone("0987654321");
+        request.setPassengerEmail("updated@example.com");
+
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+        when(ticketRepository.findByBookingTripIdAndSeatCodeIn(any(), anyList())).thenReturn(Collections.emptyList());
+        when(bookingRepository.save(any(Booking.class))).thenReturn(testBooking);
+
+        // Act
+        BookingResponse response = bookingService.updateBooking(testBooking.getId(), request);
+
+        // Assert
+        assertNotNull(response);
+        verify(bookingRepository).save(any(Booking.class));
+    }
+
+    @Test
+    void updateBooking_notPending_throwsException() {
+        // Arrange
+        testBooking.setStatus(BookingStatus.CONFIRMED);
+        UpdateBookingRequest request = new UpdateBookingRequest();
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> bookingService.updateBooking(testBooking.getId(), request));
+        assertEquals("Only pending bookings can be updated", exception.getMessage());
+    }
+
+    @Test
+    void updateBooking_withSeatConflict_throwsException() {
+        // Arrange
+        testBooking.setStatus(BookingStatus.PENDING);
+        UpdateBookingRequest request = new UpdateBookingRequest();
+        TicketRequest ticketRequest = new TicketRequest();
+        ticketRequest.setSeatCode("A2");
+        request.setTickets(Collections.singletonList(ticketRequest));
+
+        Booking otherBooking = new Booking();
+        otherBooking.setId(UUID.randomUUID());
+        Ticket conflictingTicket = new Ticket();
+        conflictingTicket.setSeatCode("A2");
+        conflictingTicket.setBooking(otherBooking);
+
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+        when(ticketRepository.findByBookingTripIdAndSeatCodeIn(any(), anyList()))
+                .thenReturn(Collections.singletonList(conflictingTicket));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> bookingService.updateBooking(testBooking.getId(), request));
+        assertTrue(exception.getMessage().contains("already booked"));
+    }
+
+    @Test
+    void checkInPassenger_success() {
+        // Arrange
+        Ticket ticket = testBooking.getTickets().get(0);
+        ticket.setBoarded(false);
+        when(ticketRepository.findById(ticket.getId())).thenReturn(Optional.of(ticket));
+        when(ticketRepository.save(any(Ticket.class))).thenReturn(ticket);
+
+        // Act
+        BookingResponse response = bookingService.checkInPassenger(ticket.getId());
+
+        // Assert
+        assertNotNull(response);
+        verify(ticketRepository).save(any(Ticket.class));
+    }
+
+    @Test
+    void checkInPassenger_ticketNotFound_throwsException() {
+        // Arrange
+        UUID ticketId = UUID.randomUUID();
+        when(ticketRepository.findById(ticketId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> bookingService.checkInPassenger(ticketId));
+        assertEquals("Ticket not found", exception.getMessage());
+    }
+
+    @Test
+    void getAdminBookings_success() {
+        // Arrange
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Booking> page = new PageImpl<>(Collections.singletonList(testBooking));
+        when(bookingRepository.findAll(ArgumentMatchers.<org.springframework.data.jpa.domain.Specification<Booking>>any(), eq(pageable))).thenReturn(page);
+
+        // Act
+        Page<BookingResponse> response = bookingService.getAdminBookings(
+                null, null, null, null, pageable);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(1, response.getTotalElements());
+    }
+
+    @Test
+    void createBooking_withSelfConflict_updatePendingBooking() {
+        // Arrange
+        CreateBookingRequest request = new CreateBookingRequest();
+        request.setTripId(testTrip.getId());
+        request.setUserId(testUser.getId());
+        request.setPassengerName("Test Passenger");
+        request.setPassengerPhone("0123456789");
+        request.setPassengerEmail("test@example.com");
+
+        TicketRequest ticketRequest = new TicketRequest();
+        ticketRequest.setSeatCode("A1");
+        ticketRequest.setPassengerName("Test Passenger");
+        ticketRequest.setPassengerPhone("0123456789");
+        ticketRequest.setPrice(new BigDecimal("200000"));
+        request.setTickets(Collections.singletonList(ticketRequest));
+
+        // Create a pending booking from the same user with same seats
+        Booking existingBooking = new Booking();
+        existingBooking.setId(UUID.randomUUID());
+        existingBooking.setStatus(BookingStatus.PENDING);
+        existingBooking.setUser(testUser);
+        existingBooking.setTrip(testTrip);
+        Ticket existingTicket = new Ticket();
+        existingTicket.setSeatCode("A1");
+        existingTicket.setBooking(existingBooking);
+        existingBooking.setTickets(Collections.singletonList(existingTicket));
+
+        when(tripRepository.findById(request.getTripId())).thenReturn(Optional.of(testTrip));
+        when(userRepository.findById(request.getUserId())).thenReturn(Optional.of(testUser));
+        when(ticketRepository.findBookedSeatCodesByTripId(request.getTripId())).thenReturn(Collections.emptyList());
+        when(ticketRepository.findByBookingTripIdAndSeatCodeIn(any(), anyList()))
+                .thenReturn(Collections.singletonList(existingTicket));
+        when(bookingRepository.save(any(Booking.class))).thenReturn(existingBooking);
+
+        // Act
+        BookingResponse response = bookingService.createBooking(request);
+
+        // Assert
+        assertNotNull(response);
+        verify(bookingRepository).save(any(Booking.class));
+    }
+
+    @Test
+    void createBooking_withPickupDropoffTripStopIds() {
+        // Arrange
+        CreateBookingRequest request = new CreateBookingRequest();
+        request.setTripId(testTrip.getId());
+        request.setUserId(testUser.getId());
+        request.setPassengerName("Test Passenger");
+        request.setPassengerPhone("0123456789");
+        request.setPassengerEmail("test@example.com");
+
+        com.awad.ticketbooking.modules.trip.entity.TripStop pickupStop = new com.awad.ticketbooking.modules.trip.entity.TripStop();
+        pickupStop.setId(UUID.randomUUID());
+        pickupStop.setStopOrder(1);
+        pickupStop.setStation(originStation);
+
+        com.awad.ticketbooking.modules.trip.entity.TripStop dropoffStop = new com.awad.ticketbooking.modules.trip.entity.TripStop();
+        dropoffStop.setId(UUID.randomUUID());
+        dropoffStop.setStopOrder(2);
+        dropoffStop.setStation(destinationStation);
+
+        testTrip.setTripStops(List.of(pickupStop, dropoffStop));
+        request.setPickupTripStopId(pickupStop.getId());
+        request.setDropoffTripStopId(dropoffStop.getId());
+
+        TicketRequest ticketRequest = new TicketRequest();
+        ticketRequest.setSeatCode("A1");
+        ticketRequest.setPassengerName("Test Passenger");
+        ticketRequest.setPassengerPhone("0123456789");
+        ticketRequest.setPrice(new BigDecimal("200000"));
+        request.setTickets(Collections.singletonList(ticketRequest));
+
+        when(tripRepository.findById(request.getTripId())).thenReturn(Optional.of(testTrip));
+        when(userRepository.findById(request.getUserId())).thenReturn(Optional.of(testUser));
+        when(ticketRepository.findBookedSeatCodesByTripId(request.getTripId())).thenReturn(Collections.emptyList());
+        when(ticketRepository.findByBookingTripIdAndSeatCodeIn(any(), anyList())).thenReturn(Collections.emptyList());
+        when(bookingRepository.findByCode(anyString())).thenReturn(Optional.empty());
+        when(bookingRepository.save(any(Booking.class))).thenAnswer(invocation -> {
+            Booking b = invocation.getArgument(0);
+            b.setId(UUID.randomUUID());
+            return b;
+        });
+
+        // Act
+        BookingResponse response = bookingService.createBooking(request);
+
+        // Assert
+        assertNotNull(response);
+        verify(bookingRepository).save(any(Booking.class));
+    }
+
+    @Test
+    void cancelBooking_confirmedWithRefund() {
+        // Arrange
+        testBooking.setStatus(BookingStatus.CONFIRMED);
+        testTrip.setDepartureTime(Instant.now().plus(48, ChronoUnit.HOURS)); // More than 24h
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+        when(bookingRepository.save(any(Booking.class))).thenReturn(testBooking);
+
+        // Act
+        BookingResponse response = bookingService.cancelBooking(testBooking.getId());
+
+        // Assert
+        assertNotNull(response);
+        verify(seatLockService).unlockSeatsForBooking(eq(testTrip.getId()), anyList());
+    }
+
+    @Test
+    void cancelBooking_confirmedDeparted_throwsException() {
+        // Arrange
+        testBooking.setStatus(BookingStatus.CONFIRMED);
+        testTrip.setDepartureTime(Instant.now().minus(1, ChronoUnit.HOURS)); // Already departed
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> bookingService.cancelBooking(testBooking.getId()));
+        assertTrue(exception.getMessage().contains("departed"));
+    }
+
+    @Test
+    void refundBooking_pending_throwsException() {
+        // Arrange
+        testBooking.setStatus(BookingStatus.PENDING);
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> bookingService.refundBooking(testBooking.getId()));
+        assertEquals("Cannot refund a pending booking", exception.getMessage());
+    }
+
+    @Test
+    void getBookingById_notFound_throwsException() {
+        // Arrange
+        UUID bookingId = UUID.randomUUID();
+        when(bookingRepository.findById(bookingId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> bookingService.getBookingById(bookingId));
+        assertEquals("Booking not found", exception.getMessage());
+    }
+
+    @Test
+    void lookupBooking_notFound_throwsException() {
+        // Arrange
+        when(bookingRepository.findByCode("INVALID")).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> bookingService.lookupBooking("INVALID", "test@example.com"));
+        assertEquals("Booking not found", exception.getMessage());
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/booking/service/SeatLockServiceTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/booking/service/SeatLockServiceTest.java
@@ -1,0 +1,211 @@
+package com.awad.ticketbooking.modules.booking.service;
+
+import com.awad.ticketbooking.modules.booking.dto.SeatStatusMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.redisson.api.RLock;
+import org.redisson.api.RMap;
+import org.redisson.api.RedissonClient;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SeatLockServiceTest {
+
+    @InjectMocks
+    private SeatLockService seatLockService;
+
+    @Mock
+    private RedissonClient redissonClient;
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @Mock
+    private RLock rLock;
+
+    @Mock
+    private RMap<Object, Object> rMap;
+
+    private UUID tripId;
+    private UUID userId;
+    private String seatCode;
+
+    @BeforeEach
+    void setUp() {
+        tripId = UUID.randomUUID();
+        userId = UUID.randomUUID();
+        seatCode = "A1";
+    }
+
+    @Test
+    void lockSeat_success() throws InterruptedException {
+        // Arrange
+        when(redissonClient.getLock(anyString())).thenReturn(rLock);
+        when(redissonClient.getMap(anyString())).thenReturn(rMap);
+        when(rLock.tryLock(eq(0L), eq(10L), eq(TimeUnit.MINUTES))).thenReturn(true);
+
+        // Act
+        boolean result = seatLockService.lockSeat(tripId, seatCode, userId);
+
+        // Assert
+        assertTrue(result);
+        verify(rMap).put(eq(seatCode), eq(userId));
+        verify(rMap).expire(10L, TimeUnit.MINUTES);
+        verify(messagingTemplate).convertAndSend(
+                eq("/topic/trip/" + tripId + "/seats"),
+                any(SeatStatusMessage.class));
+    }
+
+    @Test
+    void lockSeat_alreadyLocked_returnsFalse() throws InterruptedException {
+        // Arrange
+        when(redissonClient.getLock(anyString())).thenReturn(rLock);
+        when(rLock.tryLock(eq(0L), eq(10L), eq(TimeUnit.MINUTES))).thenReturn(false);
+
+        // Act
+        boolean result = seatLockService.lockSeat(tripId, seatCode, userId);
+
+        // Assert
+        assertFalse(result);
+        verify(rMap, never()).put(any(), any());
+    }
+
+    @Test
+    void lockSeat_interrupted_returnsFalse() throws InterruptedException {
+        // Arrange
+        when(redissonClient.getLock(anyString())).thenReturn(rLock);
+        when(rLock.tryLock(eq(0L), eq(10L), eq(TimeUnit.MINUTES))).thenThrow(new InterruptedException());
+
+        // Act
+        boolean result = seatLockService.lockSeat(tripId, seatCode, userId);
+
+        // Assert
+        assertFalse(result);
+    }
+
+    @Test
+    void unlockSeat_success() {
+        // Arrange
+        when(redissonClient.getLock(anyString())).thenReturn(rLock);
+        when(redissonClient.getMap(anyString())).thenReturn(rMap);
+        when(rLock.isLocked()).thenReturn(true);
+        when(rMap.get(eq(seatCode))).thenReturn(userId);
+
+        // Act
+        seatLockService.unlockSeat(tripId, seatCode, userId);
+
+        // Assert
+        verify(rLock).forceUnlock();
+        verify(rMap).remove(eq(seatCode));
+        verify(messagingTemplate).convertAndSend(
+                eq("/topic/trip/" + tripId + "/seats"),
+                any(SeatStatusMessage.class));
+    }
+
+    @Test
+    void unlockSeat_differentUser_doesNotUnlock() {
+        // Arrange
+        UUID differentUserId = UUID.randomUUID();
+        when(redissonClient.getLock(anyString())).thenReturn(rLock);
+        when(redissonClient.getMap(anyString())).thenReturn(rMap);
+        when(rLock.isLocked()).thenReturn(true);
+        when(rMap.get(seatCode)).thenReturn(differentUserId);
+
+        // Act
+        seatLockService.unlockSeat(tripId, seatCode, userId);
+
+        // Assert
+        verify(rLock, never()).forceUnlock();
+        verify(rMap, never()).remove(any());
+    }
+
+    @Test
+    void unlockSeat_notLocked_doesNothing() {
+        // Arrange
+        when(redissonClient.getLock(anyString())).thenReturn(rLock);
+        when(rLock.isLocked()).thenReturn(false);
+
+        // Act
+        seatLockService.unlockSeat(tripId, seatCode, userId);
+
+        // Assert
+        verify(rLock, never()).forceUnlock();
+    }
+
+    @Test
+    void unlockSeatsForBooking_success() {
+        // Arrange
+        List<String> seatCodes = List.of("A1", "A2", "B1");
+        when(redissonClient.getLock(anyString())).thenReturn(rLock);
+        when(redissonClient.getMap(anyString())).thenReturn(rMap);
+        when(rLock.isLocked()).thenReturn(true);
+        when(rMap.containsKey(any())).thenReturn(true);
+
+        // Act
+        seatLockService.unlockSeatsForBooking(tripId, seatCodes);
+
+        // Assert
+        verify(rLock, times(3)).forceUnlock();
+        verify(rMap, times(3)).remove(any());
+        verify(messagingTemplate, times(3)).convertAndSend(
+                eq("/topic/trip/" + tripId + "/seats"),
+                any(SeatStatusMessage.class));
+    }
+
+    @Test
+    void markSeatsAsBooked_success() {
+        // Arrange
+        List<String> seatCodes = List.of("A1", "A2");
+        when(redissonClient.getLock(anyString())).thenReturn(rLock);
+        when(redissonClient.getMap(anyString())).thenReturn(rMap);
+        when(rLock.isLocked()).thenReturn(true);
+        when(rMap.containsKey(any())).thenReturn(true);
+
+        // Act
+        seatLockService.markSeatsAsBooked(tripId, seatCodes);
+
+        // Assert
+        verify(rLock, times(2)).forceUnlock();
+        verify(rMap, times(2)).remove(any());
+        verify(messagingTemplate, times(2)).convertAndSend(
+                eq("/topic/trip/" + tripId + "/seats"),
+                any(SeatStatusMessage.class));
+    }
+
+    @Test
+    void getLockedSeats_success() {
+        // Arrange
+        Map<String, UUID> lockedSeats = new HashMap<>();
+        lockedSeats.put("A1", userId);
+        lockedSeats.put("A2", UUID.randomUUID());
+
+        when(redissonClient.getMap(anyString())).thenReturn(rMap);
+        when(rMap.readAllMap()).thenReturn((Map<Object, Object>) (Map<?, ?>) lockedSeats);
+
+        // Act
+        Map<String, UUID> result = seatLockService.getLockedSeats(tripId);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertTrue(result.containsKey("A1"));
+        assertTrue(result.containsKey("A2"));
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/catalog/controller/BusControllerTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/catalog/controller/BusControllerTest.java
@@ -1,0 +1,169 @@
+package com.awad.ticketbooking.modules.catalog.controller;
+
+import com.awad.ticketbooking.modules.catalog.dto.CreateBusRequest;
+import com.awad.ticketbooking.modules.catalog.entity.Bus;
+import com.awad.ticketbooking.modules.catalog.entity.BusLayout;
+import com.awad.ticketbooking.modules.catalog.entity.Operator;
+import com.awad.ticketbooking.modules.catalog.service.BusService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class BusControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private BusService busService;
+
+    @InjectMocks
+    private BusController busController;
+
+    private ObjectMapper objectMapper;
+    private Bus mockBus;
+
+    @BeforeEach
+    void setUp() {
+        PageableHandlerMethodArgumentResolver pageableResolver = new PageableHandlerMethodArgumentResolver();
+        pageableResolver.setFallbackPageable(PageRequest.of(0, 20));
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+        objectMapper.disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        org.springframework.http.converter.json.MappingJackson2HttpMessageConverter converter = 
+                new org.springframework.http.converter.json.MappingJackson2HttpMessageConverter(objectMapper);
+        mockMvc = MockMvcBuilders.standaloneSetup(busController)
+                .setCustomArgumentResolvers(pageableResolver)
+                .setMessageConverters(converter)
+                .build();
+
+        mockBus = new Bus();
+        mockBus.setId(UUID.randomUUID());
+        mockBus.setPlateNumber("ABC-123");
+    }
+
+    @Test
+    void createBus_success() throws Exception {
+        // Arrange
+        CreateBusRequest request = new CreateBusRequest();
+        request.setPlateNumber("NEW-123");
+        request.setOperatorId(UUID.randomUUID());
+        request.setBusLayoutId(UUID.randomUUID());
+        when(busService.createBus(any(CreateBusRequest.class))).thenReturn(mockBus);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/buses")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.plateNumber").value("ABC-123"));
+
+        verify(busService).createBus(any(CreateBusRequest.class));
+    }
+
+    @Test
+    void updateBus_success() throws Exception {
+        // Arrange
+        UUID busId = UUID.randomUUID();
+        CreateBusRequest request = new CreateBusRequest();
+        request.setPlateNumber("UPD-123");
+        request.setOperatorId(UUID.randomUUID());
+        request.setBusLayoutId(UUID.randomUUID());
+        when(busService.updateBus(eq(busId), any(CreateBusRequest.class))).thenReturn(mockBus);
+
+        // Act & Assert
+        mockMvc.perform(put("/api/buses/{id}", busId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        verify(busService).updateBus(eq(busId), any(CreateBusRequest.class));
+    }
+
+    @Test
+    void deleteBus_success() throws Exception {
+        // Arrange
+        UUID busId = UUID.randomUUID();
+        doNothing().when(busService).deleteBus(busId, false);
+
+        // Act & Assert
+        mockMvc.perform(delete("/api/buses/{id}", busId))
+                .andExpect(status().isNoContent());
+
+        verify(busService).deleteBus(busId, false);
+    }
+
+    @Test
+    void deleteBus_withForce_success() throws Exception {
+        // Arrange
+        UUID busId = UUID.randomUUID();
+        doNothing().when(busService).deleteBus(busId, true);
+
+        // Act & Assert
+        mockMvc.perform(delete("/api/buses/{id}", busId)
+                        .param("force", "true"))
+                .andExpect(status().isNoContent());
+
+        verify(busService).deleteBus(busId, true);
+    }
+
+    @Test
+    void getAllBuses_success() throws Exception {
+        // Arrange - Create a simpler bus with required fields for JSON serialization
+        Bus simpleBus = new Bus();
+        simpleBus.setId(UUID.randomUUID());
+        simpleBus.setPlateNumber("TEST-123");
+        // Set required fields to avoid serialization issues
+        Operator operator = new Operator();
+        operator.setId(UUID.randomUUID());
+        operator.setName("Test Operator");
+        simpleBus.setOperator(operator);
+        BusLayout busLayout = new BusLayout();
+        busLayout.setId(UUID.randomUUID());
+        busLayout.setName("Test Layout");
+        simpleBus.setBusLayout(busLayout);
+        Page<Bus> page = new PageImpl<>(Arrays.asList(simpleBus), PageRequest.of(0, 10), 1);
+        when(busService.getAllBuses(any())).thenReturn(page);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/buses")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk());
+
+        verify(busService).getAllBuses(any());
+    }
+
+    @Test
+    void getBusById_success() throws Exception {
+        // Arrange
+        UUID busId = mockBus.getId();
+        when(busService.getBusById(busId)).thenReturn(mockBus);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/buses/{id}", busId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(busId.toString()));
+
+        verify(busService).getBusById(busId);
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/catalog/controller/OperatorControllerTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/catalog/controller/OperatorControllerTest.java
@@ -1,0 +1,137 @@
+package com.awad.ticketbooking.modules.catalog.controller;
+
+import com.awad.ticketbooking.modules.catalog.dto.CreateOperatorRequest;
+import com.awad.ticketbooking.modules.catalog.entity.Operator;
+import com.awad.ticketbooking.modules.catalog.service.OperatorService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class OperatorControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private OperatorService operatorService;
+
+    @InjectMocks
+    private OperatorController operatorController;
+
+    private ObjectMapper objectMapper;
+    private Operator mockOperator;
+
+    @BeforeEach
+    void setUp() {
+        PageableHandlerMethodArgumentResolver pageableResolver = new PageableHandlerMethodArgumentResolver();
+        pageableResolver.setFallbackPageable(PageRequest.of(0, 20));
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+        objectMapper.disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        org.springframework.http.converter.json.MappingJackson2HttpMessageConverter converter = 
+                new org.springframework.http.converter.json.MappingJackson2HttpMessageConverter(objectMapper);
+        mockMvc = MockMvcBuilders.standaloneSetup(operatorController)
+                .setCustomArgumentResolvers(pageableResolver)
+                .setMessageConverters(converter)
+                .build();
+
+        mockOperator = new Operator();
+        mockOperator.setId(UUID.randomUUID());
+        mockOperator.setName("Test Operator");
+    }
+
+    @Test
+    void createOperator_success() throws Exception {
+        // Arrange
+        CreateOperatorRequest request = new CreateOperatorRequest();
+        request.setName("New Operator");
+        when(operatorService.createOperator(any(CreateOperatorRequest.class))).thenReturn(mockOperator);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/operators")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Test Operator"));
+
+        verify(operatorService).createOperator(any(CreateOperatorRequest.class));
+    }
+
+    @Test
+    void getAllOperators_success() throws Exception {
+        // Arrange
+        Page<Operator> page = new PageImpl<>(Arrays.asList(mockOperator), PageRequest.of(0, 10), 1);
+        when(operatorService.getAllOperators(any())).thenReturn(page);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/operators")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk());
+
+        verify(operatorService).getAllOperators(any());
+    }
+
+    @Test
+    void updateOperator_success() throws Exception {
+        // Arrange
+        UUID operatorId = UUID.randomUUID();
+        CreateOperatorRequest request = new CreateOperatorRequest();
+        request.setName("Updated Operator");
+        when(operatorService.updateOperator(eq(operatorId), any(CreateOperatorRequest.class))).thenReturn(mockOperator);
+
+        // Act & Assert
+        mockMvc.perform(put("/api/operators/{id}", operatorId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        verify(operatorService).updateOperator(eq(operatorId), any(CreateOperatorRequest.class));
+    }
+
+    @Test
+    void deleteOperator_success() throws Exception {
+        // Arrange
+        UUID operatorId = UUID.randomUUID();
+        doNothing().when(operatorService).deleteOperator(operatorId, false);
+
+        // Act & Assert
+        mockMvc.perform(delete("/api/operators/{id}", operatorId))
+                .andExpect(status().isNoContent());
+
+        verify(operatorService).deleteOperator(operatorId, false);
+    }
+
+    @Test
+    void deleteOperator_withForce_success() throws Exception {
+        // Arrange
+        UUID operatorId = UUID.randomUUID();
+        doNothing().when(operatorService).deleteOperator(operatorId, true);
+
+        // Act & Assert
+        mockMvc.perform(delete("/api/operators/{id}", operatorId)
+                        .param("force", "true"))
+                .andExpect(status().isNoContent());
+
+        verify(operatorService).deleteOperator(operatorId, true);
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/catalog/controller/RouteControllerTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/catalog/controller/RouteControllerTest.java
@@ -1,0 +1,222 @@
+package com.awad.ticketbooking.modules.catalog.controller;
+
+import com.awad.ticketbooking.modules.catalog.dto.AddRouteStopRequest;
+import com.awad.ticketbooking.modules.catalog.dto.CreateRouteRequest;
+import com.awad.ticketbooking.modules.catalog.dto.RouteResponse;
+import com.awad.ticketbooking.modules.catalog.service.RouteService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class RouteControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private RouteService routeService;
+
+    @InjectMocks
+    private RouteController routeController;
+
+    private ObjectMapper objectMapper;
+    private RouteResponse mockRouteResponse;
+
+    @BeforeEach
+    void setUp() {
+        PageableHandlerMethodArgumentResolver pageableResolver = new PageableHandlerMethodArgumentResolver();
+        pageableResolver.setFallbackPageable(PageRequest.of(0, 20));
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+        objectMapper.disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        org.springframework.http.converter.json.MappingJackson2HttpMessageConverter converter = 
+                new org.springframework.http.converter.json.MappingJackson2HttpMessageConverter(objectMapper);
+        mockMvc = MockMvcBuilders.standaloneSetup(routeController)
+                .setCustomArgumentResolvers(pageableResolver)
+                .setMessageConverters(converter)
+                .build();
+
+        mockRouteResponse = RouteResponse.builder()
+                .id(UUID.randomUUID())
+                .name("Route 1")
+                .durationMinutes(120)
+                .distanceKm(new BigDecimal("100.5"))
+                .isActive(true)
+                .build();
+    }
+
+    @Test
+    void getTopRoutes_success() throws Exception {
+        // Arrange
+        List<RouteResponse> routes = Arrays.asList(mockRouteResponse);
+        when(routeService.getTopRoutes()).thenReturn(routes);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/routes/top"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("Route 1"));
+
+        verify(routeService).getTopRoutes();
+    }
+
+    @Test
+    void getAllRoutes_success() throws Exception {
+        // Arrange
+        Page<RouteResponse> page = new PageImpl<>(Arrays.asList(mockRouteResponse), PageRequest.of(0, 10), 1);
+        when(routeService.getAllRoutes(any())).thenReturn(page);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/routes")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk());
+
+        verify(routeService).getAllRoutes(any());
+    }
+
+    @Test
+    void searchRoutes_success() throws Exception {
+        // Arrange
+        Page<RouteResponse> page = new PageImpl<>(Arrays.asList(mockRouteResponse), PageRequest.of(0, 10), 1);
+        when(routeService.searchRoutes(anyString(), any())).thenReturn(page);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/routes/search")
+                        .param("query", "test")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk());
+
+        verify(routeService).searchRoutes(eq("test"), any());
+    }
+
+    @Test
+    void getRouteById_success() throws Exception {
+        // Arrange
+        UUID routeId = mockRouteResponse.getId();
+        when(routeService.getRouteById(routeId)).thenReturn(mockRouteResponse);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/routes/{id}", routeId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(routeId.toString()));
+
+        verify(routeService).getRouteById(routeId);
+    }
+
+    @Test
+    void createRoute_success() throws Exception {
+        // Arrange
+        CreateRouteRequest request = new CreateRouteRequest();
+        request.setName("New Route");
+        request.setOriginStationId(UUID.randomUUID());
+        request.setDestinationStationId(UUID.randomUUID());
+        when(routeService.createRoute(any(CreateRouteRequest.class))).thenReturn(mockRouteResponse);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/routes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        verify(routeService).createRoute(any(CreateRouteRequest.class));
+    }
+
+    @Test
+    void updateRoute_success() throws Exception {
+        // Arrange
+        UUID routeId = mockRouteResponse.getId();
+        CreateRouteRequest request = new CreateRouteRequest();
+        request.setName("Updated Route");
+        request.setOriginStationId(UUID.randomUUID());
+        request.setDestinationStationId(UUID.randomUUID());
+        when(routeService.updateRoute(eq(routeId), any(CreateRouteRequest.class))).thenReturn(mockRouteResponse);
+
+        // Act & Assert
+        mockMvc.perform(put("/api/routes/{id}", routeId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        verify(routeService).updateRoute(eq(routeId), any(CreateRouteRequest.class));
+    }
+
+    @Test
+    void deleteRoute_success() throws Exception {
+        // Arrange
+        UUID routeId = UUID.randomUUID();
+        doNothing().when(routeService).deleteRoute(routeId, false);
+
+        // Act & Assert
+        mockMvc.perform(delete("/api/routes/{id}", routeId))
+                .andExpect(status().isNoContent());
+
+        verify(routeService).deleteRoute(routeId, false);
+    }
+
+    @Test
+    void deleteRoute_withForce_success() throws Exception {
+        // Arrange
+        UUID routeId = UUID.randomUUID();
+        doNothing().when(routeService).deleteRoute(routeId, true);
+
+        // Act & Assert
+        mockMvc.perform(delete("/api/routes/{id}", routeId)
+                        .param("force", "true"))
+                .andExpect(status().isNoContent());
+
+        verify(routeService).deleteRoute(routeId, true);
+    }
+
+    @Test
+    void addRouteStop_success() throws Exception {
+        // Arrange
+        UUID routeId = UUID.randomUUID();
+        AddRouteStopRequest request = new AddRouteStopRequest();
+        request.setStationId(UUID.randomUUID());
+        when(routeService.addRouteStop(eq(routeId), any(AddRouteStopRequest.class))).thenReturn(mockRouteResponse);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/routes/{id}/stops", routeId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        verify(routeService).addRouteStop(eq(routeId), any(AddRouteStopRequest.class));
+    }
+
+    @Test
+    void deleteRouteStop_success() throws Exception {
+        // Arrange
+        UUID routeId = UUID.randomUUID();
+        UUID stopId = UUID.randomUUID();
+        doNothing().when(routeService).deleteRouteStop(routeId, stopId);
+
+        // Act & Assert
+        mockMvc.perform(delete("/api/routes/{id}/stops/{stopId}", routeId, stopId))
+                .andExpect(status().isNoContent());
+
+        verify(routeService).deleteRouteStop(routeId, stopId);
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/catalog/controller/StationControllerTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/catalog/controller/StationControllerTest.java
@@ -1,0 +1,159 @@
+package com.awad.ticketbooking.modules.catalog.controller;
+
+import com.awad.ticketbooking.modules.catalog.dto.CreateStationRequest;
+import com.awad.ticketbooking.modules.catalog.entity.Station;
+import com.awad.ticketbooking.modules.catalog.service.StationService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class StationControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private StationService stationService;
+
+    @InjectMocks
+    private StationController stationController;
+
+    private ObjectMapper objectMapper;
+    private Station mockStation;
+
+    @BeforeEach
+    void setUp() {
+        PageableHandlerMethodArgumentResolver pageableResolver = new PageableHandlerMethodArgumentResolver();
+        pageableResolver.setFallbackPageable(PageRequest.of(0, 20));
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+        objectMapper.disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        org.springframework.http.converter.json.MappingJackson2HttpMessageConverter converter = 
+                new org.springframework.http.converter.json.MappingJackson2HttpMessageConverter(objectMapper);
+        mockMvc = MockMvcBuilders.standaloneSetup(stationController)
+                .setCustomArgumentResolvers(pageableResolver)
+                .setMessageConverters(converter)
+                .build();
+
+        mockStation = new Station();
+        mockStation.setId(UUID.randomUUID());
+        mockStation.setName("Test Station");
+        mockStation.setCity("Test City");
+        mockStation.setAddress("Test Address");
+    }
+
+    @Test
+    void createStation_success() throws Exception {
+        // Arrange
+        CreateStationRequest request = new CreateStationRequest();
+        request.setName("New Station");
+        request.setCity("New City");
+        request.setAddress("New Address");
+        when(stationService.createStation(any(CreateStationRequest.class))).thenReturn(mockStation);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/stations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Test Station"));
+
+        verify(stationService).createStation(any(CreateStationRequest.class));
+    }
+
+    @Test
+    void getAllStations_success() throws Exception {
+        // Arrange
+        Page<Station> page = new PageImpl<>(Arrays.asList(mockStation), PageRequest.of(0, 10), 1);
+        when(stationService.getAllStations(any())).thenReturn(page);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/stations")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk());
+
+        verify(stationService).getAllStations(any());
+    }
+
+    @Test
+    void searchStations_success() throws Exception {
+        // Arrange
+        Page<Station> page = new PageImpl<>(Arrays.asList(mockStation), PageRequest.of(0, 10), 1);
+        when(stationService.searchStations(anyString(), any())).thenReturn(page);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/stations/search")
+                        .param("query", "test")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk());
+
+        verify(stationService).searchStations(eq("test"), any());
+    }
+
+    @Test
+    void updateStation_success() throws Exception {
+        // Arrange
+        UUID stationId = UUID.randomUUID();
+        CreateStationRequest request = new CreateStationRequest();
+        request.setName("Updated Station");
+        request.setCity("Updated City");
+        request.setAddress("Updated Address");
+        when(stationService.updateStation(eq(stationId), any(CreateStationRequest.class))).thenReturn(mockStation);
+
+        // Act & Assert
+        mockMvc.perform(put("/api/stations/{id}", stationId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        verify(stationService).updateStation(eq(stationId), any(CreateStationRequest.class));
+    }
+
+    @Test
+    void deleteStation_success() throws Exception {
+        // Arrange
+        UUID stationId = UUID.randomUUID();
+        doNothing().when(stationService).deleteStation(stationId, false);
+
+        // Act & Assert
+        mockMvc.perform(delete("/api/stations/{id}", stationId))
+                .andExpect(status().isNoContent());
+
+        verify(stationService).deleteStation(stationId, false);
+    }
+
+    @Test
+    void deleteStation_withForce_success() throws Exception {
+        // Arrange
+        UUID stationId = UUID.randomUUID();
+        doNothing().when(stationService).deleteStation(stationId, true);
+
+        // Act & Assert
+        mockMvc.perform(delete("/api/stations/{id}", stationId)
+                        .param("force", "true"))
+                .andExpect(status().isNoContent());
+
+        verify(stationService).deleteStation(stationId, true);
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/catalog/service/BusLayoutServiceTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/catalog/service/BusLayoutServiceTest.java
@@ -1,0 +1,223 @@
+package com.awad.ticketbooking.modules.catalog.service;
+
+import com.awad.ticketbooking.common.enums.SeatType;
+import com.awad.ticketbooking.modules.catalog.dto.BusLayoutPayload;
+import com.awad.ticketbooking.modules.catalog.entity.BusLayout;
+import com.awad.ticketbooking.modules.catalog.entity.LayoutSeat;
+import com.awad.ticketbooking.modules.catalog.repository.BusLayoutRepository;
+import com.awad.ticketbooking.modules.catalog.repository.LayoutSeatRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class BusLayoutServiceTest {
+
+    @InjectMocks
+    private BusLayoutService busLayoutService;
+
+    @Mock
+    private BusLayoutRepository busLayoutRepository;
+
+    @Mock
+    private LayoutSeatRepository layoutSeatRepository;
+
+    @Mock
+    private EntityManager entityManager;
+
+    private BusLayout testBusLayout;
+    private BusLayoutPayload.BusLayoutRequest createRequest;
+
+    @BeforeEach
+    void setUp() {
+        testBusLayout = new BusLayout();
+        testBusLayout.setId(UUID.randomUUID());
+        testBusLayout.setName("Standard 40 Seats");
+        testBusLayout.setBusType("Standard");
+        testBusLayout.setTotalFloors(1);
+        testBusLayout.setTotalRows(10);
+        testBusLayout.setTotalCols(4);
+        testBusLayout.setTotalSeats(40);
+        testBusLayout.setDescription("Standard bus layout with 40 seats");
+
+        createRequest = new BusLayoutPayload.BusLayoutRequest();
+        createRequest.setName("Standard 40 Seats");
+        createRequest.setBusType("Standard");
+        createRequest.setTotalFloors(1);
+        createRequest.setTotalRows(10);
+        createRequest.setTotalCols(4);
+        createRequest.setDescription("Standard bus layout with 40 seats");
+    }
+
+    @Test
+    void createLayout_success() {
+        // Arrange
+        when(busLayoutRepository.save(any(BusLayout.class))).thenReturn(testBusLayout);
+
+        // Act
+        BusLayout result = busLayoutService.createLayout(createRequest);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals("Standard 40 Seats", result.getName());
+        assertEquals("Standard", result.getBusType());
+        verify(busLayoutRepository).save(any(BusLayout.class));
+    }
+
+    @Test
+    void updateLayoutMetadata_success() {
+        // Arrange
+        BusLayoutPayload.BusLayoutRequest updateRequest = new BusLayoutPayload.BusLayoutRequest();
+        updateRequest.setName("Updated Layout");
+        updateRequest.setBusType("Sleeper");
+        updateRequest.setTotalFloors(2);
+        updateRequest.setTotalRows(8);
+        updateRequest.setTotalCols(3);
+        updateRequest.setDescription("Updated description");
+
+        when(busLayoutRepository.findById(testBusLayout.getId())).thenReturn(Optional.of(testBusLayout));
+        when(busLayoutRepository.save(any(BusLayout.class))).thenReturn(testBusLayout);
+
+        // Act
+        BusLayout result = busLayoutService.updateLayoutMetadata(testBusLayout.getId(), updateRequest);
+
+        // Assert
+        assertNotNull(result);
+        verify(busLayoutRepository).save(any(BusLayout.class));
+    }
+
+    @Test
+    void updateLayoutMetadata_notFound_throwsException() {
+        // Arrange
+        UUID nonExistentId = UUID.randomUUID();
+        when(busLayoutRepository.findById(nonExistentId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> busLayoutService.updateLayoutMetadata(nonExistentId, createRequest));
+        assertEquals("Layout not found", exception.getMessage());
+    }
+
+    @Test
+    void updateLayoutSeats_success() {
+        // Arrange
+        BusLayoutPayload.SeatUpdatePayload payload = new BusLayoutPayload.SeatUpdatePayload();
+        BusLayoutPayload.LayoutSeatDto seatDto = new BusLayoutPayload.LayoutSeatDto();
+        seatDto.setSeatCode("A1");
+        seatDto.setType(SeatType.NORMAL.name());
+        seatDto.setFloor(1);
+        seatDto.setRow(0);
+        seatDto.setCol(0);
+        payload.setSeats(List.of(seatDto));
+
+        when(busLayoutRepository.findById(testBusLayout.getId())).thenReturn(Optional.of(testBusLayout));
+        when(busLayoutRepository.save(any(BusLayout.class))).thenReturn(testBusLayout);
+
+        // Act
+        busLayoutService.updateLayoutSeats(testBusLayout.getId(), payload);
+
+        // Assert
+        verify(layoutSeatRepository).deleteByBusLayoutId(testBusLayout.getId());
+        verify(entityManager).flush();
+        verify(layoutSeatRepository).saveAll(anyList());
+        verify(busLayoutRepository).save(any(BusLayout.class));
+    }
+
+    @Test
+    void updateLayoutSeats_notFound_throwsException() {
+        // Arrange
+        UUID nonExistentId = UUID.randomUUID();
+        BusLayoutPayload.SeatUpdatePayload payload = new BusLayoutPayload.SeatUpdatePayload();
+        payload.setSeats(Collections.emptyList());
+
+        when(busLayoutRepository.findById(nonExistentId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> busLayoutService.updateLayoutSeats(nonExistentId, payload));
+        assertEquals("Layout not found", exception.getMessage());
+    }
+
+    @Test
+    void deleteLayout_success() {
+        // Arrange
+        doNothing().when(layoutSeatRepository).deleteByBusLayoutId(testBusLayout.getId());
+        doNothing().when(busLayoutRepository).deleteById(testBusLayout.getId());
+
+        // Act
+        busLayoutService.deleteLayout(testBusLayout.getId());
+
+        // Assert
+        verify(layoutSeatRepository).deleteByBusLayoutId(testBusLayout.getId());
+        verify(busLayoutRepository).deleteById(testBusLayout.getId());
+    }
+
+    @Test
+    void getLayout_success() {
+        // Arrange
+        LayoutSeat seat = new LayoutSeat();
+        seat.setId(UUID.randomUUID());
+        seat.setBusLayout(testBusLayout);
+        seat.setSeatCode("A1");
+        seat.setSeatType(SeatType.NORMAL.name());
+        seat.setFloorNumber(1);
+        seat.setRowIndex(0);
+        seat.setColIndex(0);
+
+        when(busLayoutRepository.findById(testBusLayout.getId())).thenReturn(Optional.of(testBusLayout));
+        when(layoutSeatRepository.findByBusLayoutId(testBusLayout.getId()))
+                .thenReturn(Collections.singletonList(seat));
+
+        // Act
+        BusLayoutPayload.BusLayoutResponse result = busLayoutService.getLayout(testBusLayout.getId());
+
+        // Assert
+        assertNotNull(result);
+        assertEquals("Standard 40 Seats", result.getName());
+        assertEquals(1, result.getSeats().size());
+        assertEquals("A1", result.getSeats().get(0).getSeatCode());
+    }
+
+    @Test
+    void getLayout_notFound_throwsException() {
+        // Arrange
+        UUID nonExistentId = UUID.randomUUID();
+        when(busLayoutRepository.findById(nonExistentId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> busLayoutService.getLayout(nonExistentId));
+        assertEquals("Layout not found", exception.getMessage());
+    }
+
+    @Test
+    void getAllLayouts_success() {
+        // Arrange
+        when(busLayoutRepository.findAll()).thenReturn(Collections.singletonList(testBusLayout));
+
+        // Act
+        List<BusLayoutPayload.BusLayoutResponse> result = busLayoutService.getAllLayouts();
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("Standard 40 Seats", result.get(0).getName());
+        assertTrue(result.get(0).getSeats().isEmpty()); // getAllLayouts returns empty seats
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/catalog/service/BusServiceTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/catalog/service/BusServiceTest.java
@@ -1,0 +1,265 @@
+package com.awad.ticketbooking.modules.catalog.service;
+
+import com.awad.ticketbooking.modules.booking.repository.BookingRepository;
+import com.awad.ticketbooking.modules.catalog.dto.CreateBusRequest;
+import com.awad.ticketbooking.modules.catalog.entity.Bus;
+import com.awad.ticketbooking.modules.catalog.entity.BusLayout;
+import com.awad.ticketbooking.modules.catalog.entity.Operator;
+import com.awad.ticketbooking.modules.catalog.repository.BusLayoutRepository;
+import com.awad.ticketbooking.modules.catalog.repository.BusPhotoRepository;
+import com.awad.ticketbooking.modules.catalog.repository.BusRepository;
+import com.awad.ticketbooking.modules.catalog.repository.OperatorRepository;
+import com.awad.ticketbooking.modules.trip.entity.Trip;
+import com.awad.ticketbooking.modules.trip.repository.TripRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class BusServiceTest {
+
+    @InjectMocks
+    private BusService busService;
+
+    @Mock
+    private BusRepository busRepository;
+
+    @Mock
+    private OperatorRepository operatorRepository;
+
+    @Mock
+    private BusLayoutRepository busLayoutRepository;
+
+    @Mock
+    private BusPhotoRepository busPhotoRepository;
+
+    @Mock
+    private TripRepository tripRepository;
+
+    @Mock
+    private BookingRepository bookingRepository;
+
+    private Bus testBus;
+    private Operator testOperator;
+    private BusLayout testBusLayout;
+    private CreateBusRequest createRequest;
+
+    @BeforeEach
+    void setUp() {
+        testOperator = new Operator();
+        testOperator.setId(UUID.randomUUID());
+        testOperator.setName("VietBus");
+
+        testBusLayout = new BusLayout();
+        testBusLayout.setId(UUID.randomUUID());
+        testBusLayout.setName("Standard 40");
+        testBusLayout.setTotalSeats(40);
+
+        testBus = new Bus();
+        testBus.setId(UUID.randomUUID());
+        testBus.setPlateNumber("29A-12345");
+        testBus.setOperator(testOperator);
+        testBus.setBusLayout(testBusLayout);
+        testBus.setAmenities(List.of("wifi", "ac"));
+        testBus.setPhotos(new ArrayList<>());
+
+        createRequest = new CreateBusRequest();
+        createRequest.setOperatorId(testOperator.getId());
+        createRequest.setBusLayoutId(testBusLayout.getId());
+        createRequest.setPlateNumber("29A-12345");
+        createRequest.setAmenities(List.of("wifi", "ac"));
+    }
+
+    @Test
+    void createBus_success() {
+        // Arrange
+        when(operatorRepository.findById(testOperator.getId())).thenReturn(Optional.of(testOperator));
+        when(busLayoutRepository.findById(testBusLayout.getId())).thenReturn(Optional.of(testBusLayout));
+        when(busRepository.save(any(Bus.class))).thenReturn(testBus);
+
+        // Act
+        Bus result = busService.createBus(createRequest);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals("29A-12345", result.getPlateNumber());
+        assertEquals("VietBus", result.getOperator().getName());
+        verify(busRepository).save(any(Bus.class));
+    }
+
+    @Test
+    void createBus_withPhotos_success() {
+        // Arrange
+        createRequest.setPhotos(List.of("photo1.jpg", "photo2.jpg"));
+        when(operatorRepository.findById(testOperator.getId())).thenReturn(Optional.of(testOperator));
+        when(busLayoutRepository.findById(testBusLayout.getId())).thenReturn(Optional.of(testBusLayout));
+        when(busRepository.save(any(Bus.class))).thenReturn(testBus);
+
+        // Act
+        Bus result = busService.createBus(createRequest);
+
+        // Assert
+        assertNotNull(result);
+        verify(busPhotoRepository).saveAll(anyList());
+    }
+
+    @Test
+    void createBus_operatorNotFound_throwsException() {
+        // Arrange
+        when(operatorRepository.findById(testOperator.getId())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> busService.createBus(createRequest));
+        assertEquals("Operator not found", exception.getMessage());
+    }
+
+    @Test
+    void createBus_busLayoutNotFound_throwsException() {
+        // Arrange
+        when(operatorRepository.findById(testOperator.getId())).thenReturn(Optional.of(testOperator));
+        when(busLayoutRepository.findById(testBusLayout.getId())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> busService.createBus(createRequest));
+        assertEquals("Bus layout not found", exception.getMessage());
+    }
+
+    @Test
+    void updateBus_success() {
+        // Arrange
+        CreateBusRequest updateRequest = new CreateBusRequest();
+        updateRequest.setOperatorId(testOperator.getId());
+        updateRequest.setBusLayoutId(testBusLayout.getId());
+        updateRequest.setPlateNumber("30B-54321");
+        updateRequest.setAmenities(List.of("wifi"));
+
+        when(busRepository.findById(testBus.getId())).thenReturn(Optional.of(testBus));
+        when(operatorRepository.findById(testOperator.getId())).thenReturn(Optional.of(testOperator));
+        when(busLayoutRepository.findById(testBusLayout.getId())).thenReturn(Optional.of(testBusLayout));
+        when(busRepository.save(any(Bus.class))).thenReturn(testBus);
+
+        // Act
+        Bus result = busService.updateBus(testBus.getId(), updateRequest);
+
+        // Assert
+        assertNotNull(result);
+        verify(busRepository).save(any(Bus.class));
+    }
+
+    @Test
+    void updateBus_notFound_throwsException() {
+        // Arrange
+        UUID nonExistentId = UUID.randomUUID();
+        when(busRepository.findById(nonExistentId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> busService.updateBus(nonExistentId, createRequest));
+        assertEquals("Bus not found", exception.getMessage());
+    }
+
+    @Test
+    void deleteBus_success() {
+        // Arrange
+        when(busRepository.existsById(testBus.getId())).thenReturn(true);
+        doNothing().when(busRepository).deleteById(testBus.getId());
+
+        // Act
+        busService.deleteBus(testBus.getId(), false);
+
+        // Assert
+        verify(busRepository).deleteById(testBus.getId());
+    }
+
+    @Test
+    void deleteBus_notFound_throwsException() {
+        // Arrange
+        UUID nonExistentId = UUID.randomUUID();
+        when(busRepository.existsById(nonExistentId)).thenReturn(false);
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> busService.deleteBus(nonExistentId, false));
+        assertEquals("Bus not found", exception.getMessage());
+    }
+
+    @Test
+    void deleteBus_force_cascadesDeletes() {
+        // Arrange
+        Trip trip = new Trip();
+        trip.setId(UUID.randomUUID());
+
+        when(busRepository.existsById(testBus.getId())).thenReturn(true);
+        when(tripRepository.findByBusId(testBus.getId())).thenReturn(Collections.singletonList(trip));
+
+        // Act
+        busService.deleteBus(testBus.getId(), true);
+
+        // Assert
+        verify(bookingRepository).deleteByTripId(trip.getId());
+        verify(tripRepository).deleteByBusId(testBus.getId());
+        verify(busRepository).deleteById(testBus.getId());
+    }
+
+    @Test
+    void getBusById_success() {
+        // Arrange
+        when(busRepository.findById(testBus.getId())).thenReturn(Optional.of(testBus));
+
+        // Act
+        Bus result = busService.getBusById(testBus.getId());
+
+        // Assert
+        assertNotNull(result);
+        assertEquals("29A-12345", result.getPlateNumber());
+    }
+
+    @Test
+    void getBusById_notFound_throwsException() {
+        // Arrange
+        UUID nonExistentId = UUID.randomUUID();
+        when(busRepository.findById(nonExistentId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> busService.getBusById(nonExistentId));
+        assertEquals("Bus not found", exception.getMessage());
+    }
+
+    @Test
+    void getAllBuses_success() {
+        // Arrange
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Bus> page = new PageImpl<>(Collections.singletonList(testBus));
+        when(busRepository.findAll(pageable)).thenReturn(page);
+
+        // Act
+        Page<Bus> result = busService.getAllBuses(pageable);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/catalog/service/OperatorServiceTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/catalog/service/OperatorServiceTest.java
@@ -1,0 +1,168 @@
+package com.awad.ticketbooking.modules.catalog.service;
+
+import com.awad.ticketbooking.modules.booking.repository.BookingRepository;
+import com.awad.ticketbooking.modules.catalog.dto.CreateOperatorRequest;
+import com.awad.ticketbooking.modules.catalog.entity.Bus;
+import com.awad.ticketbooking.modules.catalog.entity.Operator;
+import com.awad.ticketbooking.modules.catalog.repository.BusRepository;
+import com.awad.ticketbooking.modules.catalog.repository.OperatorRepository;
+import com.awad.ticketbooking.modules.trip.entity.Trip;
+import com.awad.ticketbooking.modules.trip.repository.TripRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class OperatorServiceTest {
+
+    @InjectMocks
+    private OperatorService operatorService;
+
+    @Mock
+    private OperatorRepository operatorRepository;
+
+    @Mock
+    private BusRepository busRepository;
+
+    @Mock
+    private TripRepository tripRepository;
+
+    @Mock
+    private BookingRepository bookingRepository;
+
+    private Operator testOperator;
+    private CreateOperatorRequest createRequest;
+
+    @BeforeEach
+    void setUp() {
+        testOperator = new Operator();
+        testOperator.setId(UUID.randomUUID());
+        testOperator.setName("VietBus");
+        Map<String, Object> contactInfo = new HashMap<>();
+        contactInfo.put("email", "contact@vietbus.com");
+        testOperator.setContactInfo(contactInfo);
+
+        createRequest = new CreateOperatorRequest();
+        createRequest.setName("VietBus");
+        createRequest.setContactInfo(contactInfo);
+    }
+
+    @Test
+    void createOperator_success() {
+        // Arrange
+        when(operatorRepository.save(any(Operator.class))).thenReturn(testOperator);
+
+        // Act
+        Operator result = operatorService.createOperator(createRequest);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals("VietBus", result.getName());
+        assertNotNull(result.getContactInfo());
+        assertEquals("contact@vietbus.com", result.getContactInfo().get("email"));
+        verify(operatorRepository).save(any(Operator.class));
+    }
+
+    @Test
+    void getAllOperators_success() {
+        // Arrange
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Operator> page = new PageImpl<>(Collections.singletonList(testOperator));
+        when(operatorRepository.findAll(pageable)).thenReturn(page);
+
+        // Act
+        Page<Operator> result = operatorService.getAllOperators(pageable);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        assertEquals("VietBus", result.getContent().get(0).getName());
+    }
+
+    @Test
+    void updateOperator_success() {
+        // Arrange
+        CreateOperatorRequest updateRequest = new CreateOperatorRequest();
+        updateRequest.setName("Updated Operator");
+        Map<String, Object> newContactInfo = new HashMap<>();
+        newContactInfo.put("email", "new@contact.com");
+        updateRequest.setContactInfo(newContactInfo);
+
+        when(operatorRepository.findById(testOperator.getId())).thenReturn(Optional.of(testOperator));
+        when(operatorRepository.save(any(Operator.class))).thenReturn(testOperator);
+
+        // Act
+        Operator result = operatorService.updateOperator(testOperator.getId(), updateRequest);
+
+        // Assert
+        assertNotNull(result);
+        verify(operatorRepository).save(any(Operator.class));
+    }
+
+    @Test
+    void updateOperator_notFound_throwsException() {
+        // Arrange
+        UUID nonExistentId = UUID.randomUUID();
+        when(operatorRepository.findById(nonExistentId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(IllegalArgumentException.class,
+                () -> operatorService.updateOperator(nonExistentId, createRequest));
+    }
+
+    @Test
+    void deleteOperator_success() {
+        // Arrange
+        doNothing().when(operatorRepository).deleteById(testOperator.getId());
+
+        // Act
+        operatorService.deleteOperator(testOperator.getId(), false);
+
+        // Assert
+        verify(operatorRepository).deleteById(testOperator.getId());
+    }
+
+    @Test
+    void deleteOperator_force_cascadesDeletes() {
+        // Arrange
+        Bus bus = new Bus();
+        bus.setId(UUID.randomUUID());
+
+        Trip trip = new Trip();
+        trip.setId(UUID.randomUUID());
+
+        when(busRepository.findByOperatorId(testOperator.getId()))
+                .thenReturn(Collections.singletonList(bus));
+        when(tripRepository.findByBusId(bus.getId()))
+                .thenReturn(Collections.singletonList(trip));
+
+        // Act
+        operatorService.deleteOperator(testOperator.getId(), true);
+
+        // Assert
+        verify(bookingRepository).deleteByTripId(trip.getId());
+        verify(tripRepository).deleteByBusId(bus.getId());
+        verify(busRepository).deleteByOperatorId(testOperator.getId());
+        verify(operatorRepository).deleteById(testOperator.getId());
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/catalog/service/RouteServiceTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/catalog/service/RouteServiceTest.java
@@ -1,0 +1,415 @@
+package com.awad.ticketbooking.modules.catalog.service;
+
+import com.awad.ticketbooking.common.enums.StopType;
+import com.awad.ticketbooking.modules.booking.repository.BookingRepository;
+import com.awad.ticketbooking.modules.catalog.dto.AddRouteStopRequest;
+import com.awad.ticketbooking.modules.catalog.dto.CreateRouteRequest;
+import com.awad.ticketbooking.modules.catalog.dto.RouteResponse;
+import com.awad.ticketbooking.modules.catalog.entity.Route;
+import com.awad.ticketbooking.modules.catalog.entity.RouteStop;
+import com.awad.ticketbooking.modules.catalog.entity.Station;
+import com.awad.ticketbooking.modules.catalog.repository.RouteRepository;
+import com.awad.ticketbooking.modules.catalog.repository.RouteStopRepository;
+import com.awad.ticketbooking.modules.catalog.repository.StationRepository;
+import com.awad.ticketbooking.modules.trip.entity.Trip;
+import com.awad.ticketbooking.modules.trip.repository.TripRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class RouteServiceTest {
+
+    @InjectMocks
+    private RouteService routeService;
+
+    @Mock
+    private RouteRepository routeRepository;
+
+    @Mock
+    private RouteStopRepository routeStopRepository;
+
+    @Mock
+    private StationRepository stationRepository;
+
+    @Mock
+    private BookingRepository bookingRepository;
+
+    @Mock
+    private TripRepository tripRepository;
+
+    private Route testRoute;
+    private Station originStation;
+    private Station destinationStation;
+    private CreateRouteRequest createRequest;
+
+    @BeforeEach
+    void setUp() {
+        originStation = new Station();
+        originStation.setId(UUID.randomUUID());
+        originStation.setName("Hanoi Station");
+        originStation.setCity("Hanoi");
+        originStation.setAddress("123 Main St");
+
+        destinationStation = new Station();
+        destinationStation.setId(UUID.randomUUID());
+        destinationStation.setName("Saigon Station");
+        destinationStation.setCity("Saigon");
+        destinationStation.setAddress("456 Main St");
+
+        testRoute = new Route();
+        testRoute.setId(UUID.randomUUID());
+        testRoute.setName("Hanoi - Saigon Express");
+        testRoute.setOriginStation(originStation);
+        testRoute.setDestinationStation(destinationStation);
+        testRoute.setDurationMinutes(360);
+        testRoute.setDistanceKm(BigDecimal.valueOf(1800));
+        testRoute.setIsActive(true);
+        testRoute.setStops(new ArrayList<>());
+
+        createRequest = new CreateRouteRequest();
+        createRequest.setName("Hanoi - Saigon Express");
+        createRequest.setOriginStationId(originStation.getId());
+        createRequest.setDestinationStationId(destinationStation.getId());
+        createRequest.setDurationMinutes(360);
+        createRequest.setDistanceKm(BigDecimal.valueOf(1800));
+    }
+
+    @Test
+    void createRoute_success() {
+        // Arrange
+        when(stationRepository.findById(originStation.getId())).thenReturn(Optional.of(originStation));
+        when(stationRepository.findById(destinationStation.getId())).thenReturn(Optional.of(destinationStation));
+        when(routeRepository.save(any(Route.class))).thenReturn(testRoute);
+
+        // Act
+        RouteResponse result = routeService.createRoute(createRequest);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals("Hanoi - Saigon Express", result.getName());
+        assertEquals("Hanoi", result.getOriginStation().getCity());
+        assertEquals("Saigon", result.getDestinationStation().getCity());
+        verify(routeRepository).save(any(Route.class));
+    }
+
+    @Test
+    void createRoute_originNotFound_throwsException() {
+        // Arrange
+        when(stationRepository.findById(originStation.getId())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> routeService.createRoute(createRequest));
+        assertEquals("Origin station not found", exception.getMessage());
+    }
+
+    @Test
+    void createRoute_destinationNotFound_throwsException() {
+        // Arrange
+        when(stationRepository.findById(originStation.getId())).thenReturn(Optional.of(originStation));
+        when(stationRepository.findById(destinationStation.getId())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> routeService.createRoute(createRequest));
+        assertEquals("Destination station not found", exception.getMessage());
+    }
+
+    @Test
+    void updateRoute_success() {
+        // Arrange
+        CreateRouteRequest updateRequest = new CreateRouteRequest();
+        updateRequest.setName("Updated Route");
+        updateRequest.setOriginStationId(originStation.getId());
+        updateRequest.setDestinationStationId(destinationStation.getId());
+        updateRequest.setDurationMinutes(400);
+        updateRequest.setDistanceKm(BigDecimal.valueOf(2000));
+
+        when(routeRepository.findById(testRoute.getId())).thenReturn(Optional.of(testRoute));
+        when(stationRepository.findById(originStation.getId())).thenReturn(Optional.of(originStation));
+        when(stationRepository.findById(destinationStation.getId())).thenReturn(Optional.of(destinationStation));
+        when(routeRepository.save(any(Route.class))).thenReturn(testRoute);
+
+        // Act
+        RouteResponse result = routeService.updateRoute(testRoute.getId(), updateRequest);
+
+        // Assert
+        assertNotNull(result);
+        verify(routeRepository).save(any(Route.class));
+    }
+
+    @Test
+    void updateRoute_notFound_throwsException() {
+        // Arrange
+        UUID nonExistentId = UUID.randomUUID();
+        when(routeRepository.findById(nonExistentId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> routeService.updateRoute(nonExistentId, createRequest));
+        assertEquals("Route not found", exception.getMessage());
+    }
+
+    @Test
+    void deleteRoute_success() {
+        // Arrange
+        when(routeRepository.existsById(testRoute.getId())).thenReturn(true);
+        doNothing().when(routeRepository).deleteById(testRoute.getId());
+
+        // Act
+        routeService.deleteRoute(testRoute.getId(), false);
+
+        // Assert
+        verify(routeRepository).deleteById(testRoute.getId());
+    }
+
+    @Test
+    void deleteRoute_notFound_throwsException() {
+        // Arrange
+        UUID nonExistentId = UUID.randomUUID();
+        when(routeRepository.existsById(nonExistentId)).thenReturn(false);
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> routeService.deleteRoute(nonExistentId, false));
+        assertEquals("Route not found", exception.getMessage());
+    }
+
+    @Test
+    void deleteRoute_force_cascadesDeletes() {
+        // Arrange
+        Trip trip = new Trip();
+        trip.setId(UUID.randomUUID());
+
+        when(routeRepository.existsById(testRoute.getId())).thenReturn(true);
+        when(tripRepository.findByRouteId(testRoute.getId())).thenReturn(Collections.singletonList(trip));
+
+        // Act
+        routeService.deleteRoute(testRoute.getId(), true);
+
+        // Assert
+        verify(bookingRepository).deleteByTripId(trip.getId());
+        verify(tripRepository).deleteByRouteId(testRoute.getId());
+        verify(routeRepository).deleteById(testRoute.getId());
+    }
+
+    @Test
+    void getRouteById_success() {
+        // Arrange
+        when(routeRepository.findById(testRoute.getId())).thenReturn(Optional.of(testRoute));
+
+        // Act
+        RouteResponse result = routeService.getRouteById(testRoute.getId());
+
+        // Assert
+        assertNotNull(result);
+        assertEquals("Hanoi - Saigon Express", result.getName());
+    }
+
+    @Test
+    void getRouteById_notFound_throwsException() {
+        // Arrange
+        UUID nonExistentId = UUID.randomUUID();
+        when(routeRepository.findById(nonExistentId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> routeService.getRouteById(nonExistentId));
+        assertEquals("Route not found", exception.getMessage());
+    }
+
+    @Test
+    void getAllRoutes_success() {
+        // Arrange
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Route> page = new PageImpl<>(Collections.singletonList(testRoute));
+        when(routeRepository.findAll(pageable)).thenReturn(page);
+
+        // Act
+        Page<RouteResponse> result = routeService.getAllRoutes(pageable);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+    }
+
+    @Test
+    void addRouteStop_success() {
+        // Arrange
+        Station stopStation = new Station();
+        stopStation.setId(UUID.randomUUID());
+        stopStation.setName("Hue Station");
+        stopStation.setCity("Hue");
+
+        AddRouteStopRequest stopRequest = new AddRouteStopRequest();
+        stopRequest.setStationId(stopStation.getId());
+        stopRequest.setStopOrder(1);
+        stopRequest.setDurationMinutesFromOrigin(120);
+        stopRequest.setStopType(StopType.BOTH);
+
+        RouteStop savedStop = new RouteStop();
+        savedStop.setId(UUID.randomUUID());
+        savedStop.setRoute(testRoute);
+        savedStop.setStation(stopStation);
+        savedStop.setStopOrder(1);
+        savedStop.setDurationMinutesFromOrigin(120);
+        savedStop.setStopType(StopType.BOTH);
+
+        when(routeRepository.findById(testRoute.getId())).thenReturn(Optional.of(testRoute));
+        when(stationRepository.findById(stopStation.getId())).thenReturn(Optional.of(stopStation));
+        when(routeStopRepository.save(any(RouteStop.class))).thenReturn(savedStop);
+
+        // Act
+        RouteResponse result = routeService.addRouteStop(testRoute.getId(), stopRequest);
+
+        // Assert
+        assertNotNull(result);
+        verify(routeStopRepository).save(any(RouteStop.class));
+    }
+
+    @Test
+    void addRouteStop_invalidTime_throwsException() {
+        // Arrange
+        Station stopStation = new Station();
+        stopStation.setId(UUID.randomUUID());
+        stopStation.setName("Test Station");
+        
+        AddRouteStopRequest stopRequest = new AddRouteStopRequest();
+        stopRequest.setStationId(stopStation.getId());
+        stopRequest.setStopOrder(1);
+        stopRequest.setDurationMinutesFromOrigin(0); // Invalid: must be > 0
+        stopRequest.setStopType(StopType.BOTH);
+
+        when(routeRepository.findById(testRoute.getId())).thenReturn(Optional.of(testRoute));
+        when(stationRepository.findById(stopStation.getId())).thenReturn(Optional.of(stopStation));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> routeService.addRouteStop(testRoute.getId(), stopRequest));
+        assertNotNull(exception);
+        assertTrue(exception.getMessage() != null && 
+                   (exception.getMessage().contains("phải lớn hơn 0") || 
+                    exception.getMessage().contains("lớn hơn 0")));
+    }
+
+    @Test
+    void addRouteStop_timeExceedsRouteDuration_throwsException() {
+        // Arrange
+        Station stopStation = new Station();
+        stopStation.setId(UUID.randomUUID());
+        stopStation.setName("Test Station");
+        
+        AddRouteStopRequest stopRequest = new AddRouteStopRequest();
+        stopRequest.setStationId(stopStation.getId());
+        stopRequest.setStopOrder(1);
+        stopRequest.setDurationMinutesFromOrigin(400); // Greater than route duration (360)
+        stopRequest.setStopType(StopType.BOTH);
+
+        when(routeRepository.findById(testRoute.getId())).thenReturn(Optional.of(testRoute));
+        when(stationRepository.findById(stopStation.getId())).thenReturn(Optional.of(stopStation));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> routeService.addRouteStop(testRoute.getId(), stopRequest));
+        assertNotNull(exception);
+        assertTrue(exception.getMessage() != null && 
+                   (exception.getMessage().contains("nhỏ hơn tổng thời gian tuyến") || 
+                    exception.getMessage().contains("nhỏ hơn")));
+    }
+
+    @Test
+    void addRouteStop_withCustomName_success() {
+        // Arrange
+        AddRouteStopRequest stopRequest = new AddRouteStopRequest();
+        stopRequest.setCustomName("Rest Stop A");
+        stopRequest.setCustomAddress("Highway 1, KM 50");
+        stopRequest.setStopOrder(1);
+        stopRequest.setDurationMinutesFromOrigin(60);
+        stopRequest.setStopType(StopType.BOTH);
+
+        RouteStop savedStop = new RouteStop();
+        savedStop.setId(UUID.randomUUID());
+        savedStop.setRoute(testRoute);
+        savedStop.setCustomName("Rest Stop A");
+
+        when(routeRepository.findById(testRoute.getId())).thenReturn(Optional.of(testRoute));
+        when(routeStopRepository.save(any(RouteStop.class))).thenReturn(savedStop);
+
+        // Act
+        RouteResponse result = routeService.addRouteStop(testRoute.getId(), stopRequest);
+
+        // Assert
+        assertNotNull(result);
+        verify(routeStopRepository).save(any(RouteStop.class));
+    }
+
+    @Test
+    void deleteRouteStop_success() {
+        // Arrange
+        RouteStop stop = new RouteStop();
+        stop.setId(UUID.randomUUID());
+        stop.setRoute(testRoute);
+
+        when(routeStopRepository.findById(stop.getId())).thenReturn(Optional.of(stop));
+
+        // Act
+        routeService.deleteRouteStop(testRoute.getId(), stop.getId());
+
+        // Assert
+        verify(routeStopRepository).delete(stop);
+    }
+
+    @Test
+    void deleteRouteStop_notBelongToRoute_throwsException() {
+        // Arrange
+        Route otherRoute = new Route();
+        otherRoute.setId(UUID.randomUUID());
+
+        RouteStop stop = new RouteStop();
+        stop.setId(UUID.randomUUID());
+        stop.setRoute(otherRoute);
+
+        when(routeStopRepository.findById(stop.getId())).thenReturn(Optional.of(stop));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> routeService.deleteRouteStop(testRoute.getId(), stop.getId()));
+        assertEquals("Stop does not belong to this route", exception.getMessage());
+    }
+
+    @Test
+    void searchRoutes_success() {
+        // Arrange
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Route> page = new PageImpl<>(Collections.singletonList(testRoute));
+        when(routeRepository.search("Hanoi", pageable)).thenReturn(page);
+
+        // Act
+        Page<RouteResponse> result = routeService.searchRoutes("Hanoi", pageable);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/catalog/service/StationServiceTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/catalog/service/StationServiceTest.java
@@ -1,0 +1,182 @@
+package com.awad.ticketbooking.modules.catalog.service;
+
+import com.awad.ticketbooking.modules.booking.repository.BookingRepository;
+import com.awad.ticketbooking.modules.catalog.dto.CreateStationRequest;
+import com.awad.ticketbooking.modules.catalog.entity.Route;
+import com.awad.ticketbooking.modules.catalog.entity.Station;
+import com.awad.ticketbooking.modules.catalog.repository.RouteRepository;
+import com.awad.ticketbooking.modules.catalog.repository.StationRepository;
+import com.awad.ticketbooking.modules.trip.entity.Trip;
+import com.awad.ticketbooking.modules.trip.repository.TripRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class StationServiceTest {
+
+    @InjectMocks
+    private StationService stationService;
+
+    @Mock
+    private StationRepository stationRepository;
+
+    @Mock
+    private RouteRepository routeRepository;
+
+    @Mock
+    private TripRepository tripRepository;
+
+    @Mock
+    private BookingRepository bookingRepository;
+
+    private Station testStation;
+    private CreateStationRequest createRequest;
+
+    @BeforeEach
+    void setUp() {
+        testStation = new Station();
+        testStation.setId(UUID.randomUUID());
+        testStation.setName("Hanoi Station");
+        testStation.setCity("Hanoi");
+        testStation.setAddress("123 Main St, Hanoi");
+
+        createRequest = new CreateStationRequest();
+        createRequest.setName("Hanoi Station");
+        createRequest.setCity("Hanoi");
+        createRequest.setAddress("123 Main St, Hanoi");
+    }
+
+    @Test
+    void createStation_success() {
+        // Arrange
+        when(stationRepository.save(any(Station.class))).thenReturn(testStation);
+
+        // Act
+        Station result = stationService.createStation(createRequest);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals("Hanoi Station", result.getName());
+        assertEquals("Hanoi", result.getCity());
+        verify(stationRepository).save(any(Station.class));
+    }
+
+    @Test
+    void getAllStations_success() {
+        // Arrange
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Station> page = new PageImpl<>(Collections.singletonList(testStation));
+        when(stationRepository.findAll(pageable)).thenReturn(page);
+
+        // Act
+        Page<Station> result = stationService.getAllStations(pageable);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        assertEquals("Hanoi Station", result.getContent().get(0).getName());
+    }
+
+    @Test
+    void searchStations_success() {
+        // Arrange
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Station> page = new PageImpl<>(Collections.singletonList(testStation));
+        when(stationRepository.search("Hanoi", pageable)).thenReturn(page);
+
+        // Act
+        Page<Station> result = stationService.searchStations("Hanoi", pageable);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+    }
+
+    @Test
+    void updateStation_success() {
+        // Arrange
+        CreateStationRequest updateRequest = new CreateStationRequest();
+        updateRequest.setName("Updated Station");
+        updateRequest.setCity("Ho Chi Minh");
+        updateRequest.setAddress("456 New St");
+
+        when(stationRepository.findById(testStation.getId())).thenReturn(Optional.of(testStation));
+        when(stationRepository.save(any(Station.class))).thenReturn(testStation);
+
+        // Act
+        Station result = stationService.updateStation(testStation.getId(), updateRequest);
+
+        // Assert
+        assertNotNull(result);
+        verify(stationRepository).save(any(Station.class));
+    }
+
+    @Test
+    void updateStation_notFound_throwsException() {
+        // Arrange
+        UUID nonExistentId = UUID.randomUUID();
+        when(stationRepository.findById(nonExistentId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(IllegalArgumentException.class,
+                () -> stationService.updateStation(nonExistentId, createRequest));
+    }
+
+    @Test
+    void deleteStation_success() {
+        // Arrange
+        doNothing().when(stationRepository).deleteById(testStation.getId());
+
+        // Act
+        stationService.deleteStation(testStation.getId(), false);
+
+        // Assert
+        verify(stationRepository).deleteById(testStation.getId());
+    }
+
+    @Test
+    void deleteStation_force_cascadesDeletes() {
+        // Arrange
+        Route route = new Route();
+        route.setId(UUID.randomUUID());
+
+        Trip trip = new Trip();
+        trip.setId(UUID.randomUUID());
+
+        when(routeRepository.findByOriginStationId(testStation.getId()))
+                .thenReturn(Collections.singletonList(route));
+        when(routeRepository.findByDestinationStationId(testStation.getId()))
+                .thenReturn(Collections.emptyList());
+        when(tripRepository.findByRouteId(route.getId()))
+                .thenReturn(Collections.singletonList(trip));
+
+        // Act
+        stationService.deleteStation(testStation.getId(), true);
+
+        // Assert
+        verify(bookingRepository).deleteByTripId(trip.getId());
+        verify(tripRepository).deleteByRouteId(route.getId());
+        verify(routeRepository).deleteByOriginStationId(testStation.getId());
+        verify(stationRepository).deleteById(testStation.getId());
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/dashboard/service/AdminDashboardServiceTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/dashboard/service/AdminDashboardServiceTest.java
@@ -1,0 +1,480 @@
+package com.awad.ticketbooking.modules.dashboard.service;
+
+import com.awad.ticketbooking.common.enums.BookingStatus;
+import com.awad.ticketbooking.modules.auth.repository.UserRepository;
+import com.awad.ticketbooking.modules.booking.entity.Booking;
+import com.awad.ticketbooking.modules.booking.repository.BookingRepository;
+import com.awad.ticketbooking.modules.catalog.entity.Operator;
+import com.awad.ticketbooking.modules.catalog.entity.Route;
+import com.awad.ticketbooking.modules.catalog.entity.Station;
+import com.awad.ticketbooking.modules.dashboard.dto.*;
+import com.awad.ticketbooking.modules.trip.entity.Trip;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.PageRequest;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AdminDashboardServiceTest {
+
+    @InjectMocks
+    private AdminDashboardService adminDashboardService;
+
+    @Mock
+    private BookingRepository bookingRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private Route testRoute;
+    private Operator testOperator;
+    private Booking testBooking;
+
+    @BeforeEach
+    void setUp() {
+        // Setup stations
+        Station originStation = new Station();
+        originStation.setId(UUID.randomUUID());
+        originStation.setName("Hanoi");
+        originStation.setCity("Hanoi");
+
+        Station destStation = new Station();
+        destStation.setId(UUID.randomUUID());
+        destStation.setName("Saigon");
+        destStation.setCity("Saigon");
+
+        // Setup route
+        testRoute = new Route();
+        testRoute.setId(UUID.randomUUID());
+        testRoute.setOriginStation(originStation);
+        testRoute.setDestinationStation(destStation);
+
+        // Setup operator
+        testOperator = new Operator();
+        testOperator.setId(UUID.randomUUID());
+        testOperator.setName("VietBus");
+
+        // Setup trip
+        Trip trip = new Trip();
+        trip.setId(UUID.randomUUID());
+        trip.setRoute(testRoute);
+
+        // Setup booking
+        testBooking = new Booking();
+        testBooking.setId(UUID.randomUUID());
+        testBooking.setTrip(trip);
+        testBooking.setPassengerName("Test Passenger");
+        testBooking.setTotalPrice(new BigDecimal("200000"));
+        testBooking.setStatus(BookingStatus.CONFIRMED);
+        testBooking.setCreatedAt(Instant.now());
+    }
+
+    @Test
+    void getMetrics_success() {
+        // Arrange
+        when(bookingRepository.sumTotalPriceByCreatedAtBetweenAndStatus(any(), any(), eq(BookingStatus.CONFIRMED)))
+                .thenReturn(new BigDecimal("1000000"));
+        when(bookingRepository.countByCreatedAtBetweenAndStatus(any(), any(), eq(BookingStatus.CONFIRMED)))
+                .thenReturn(50L);
+        when(userRepository.countByCreatedAtBetween(any(), any())).thenReturn(10L);
+        when(bookingRepository.countDistinctOperators(any(), any(), eq(BookingStatus.CONFIRMED))).thenReturn(5L);
+
+        // Act
+        MetricsResponse response = adminDashboardService.getMetrics();
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(new BigDecimal("1000000"), response.getTodayRevenue());
+        assertEquals(50L, response.getTodayTicketsSold());
+        assertEquals(10L, response.getTodayNewUsers());
+        assertEquals(5L, response.getTodayActiveOperators());
+    }
+
+    @Test
+    void getMetrics_nullRevenue_returnsZero() {
+        // Arrange
+        when(bookingRepository.sumTotalPriceByCreatedAtBetweenAndStatus(any(), any(), eq(BookingStatus.CONFIRMED)))
+                .thenReturn(null);
+        when(bookingRepository.countByCreatedAtBetweenAndStatus(any(), any(), eq(BookingStatus.CONFIRMED)))
+                .thenReturn(0L);
+        when(userRepository.countByCreatedAtBetween(any(), any())).thenReturn(0L);
+        when(bookingRepository.countDistinctOperators(any(), any(), eq(BookingStatus.CONFIRMED))).thenReturn(0L);
+
+        // Act
+        MetricsResponse response = adminDashboardService.getMetrics();
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(BigDecimal.ZERO, response.getTodayRevenue());
+    }
+
+    @Test
+    void getRevenueChart_success() {
+        // Arrange
+        Instant start = Instant.now().minusSeconds(86400 * 7);
+        Instant end = Instant.now();
+
+        Object[] row = new Object[]{"2025-01-01", new BigDecimal("500000")};
+        List<Object[]> data = Collections.singletonList(row);
+
+        when(bookingRepository.getRevenueChartData(start, end)).thenReturn(data);
+
+        // Act
+        List<RevenueChartResponse> response = adminDashboardService.getRevenueChart(start, end);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(1, response.size());
+        assertEquals("2025-01-01", response.get(0).getDate());
+        assertEquals(new BigDecimal("500000"), response.get(0).getRevenue());
+    }
+
+    @Test
+    void getTopRoutes_success() {
+        // Arrange
+        Object[] row = new Object[]{testRoute, 100L};
+        List<Object[]> data = Collections.singletonList(row);
+
+        when(bookingRepository.findTopRoutes(any(PageRequest.class))).thenReturn(data);
+
+        // Act
+        List<TopRouteResponse> response = adminDashboardService.getTopRoutes(5);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(1, response.size());
+        assertEquals("Hanoi", response.get(0).getOrigin());
+        assertEquals("Saigon", response.get(0).getDestination());
+        assertEquals(100L, response.get(0).getTicketsSold());
+    }
+
+    @Test
+    void getTopRoutes_withDateRange_success() {
+        // Arrange
+        Instant start = Instant.now().minusSeconds(86400 * 7);
+        Instant end = Instant.now();
+
+        Object[] row = new Object[]{testRoute, 50L};
+        List<Object[]> data = Collections.singletonList(row);
+
+        when(bookingRepository.findTopRoutesInRange(eq(start), eq(end), any(PageRequest.class))).thenReturn(data);
+
+        // Act
+        List<TopRouteResponse> response = adminDashboardService.getTopRoutes(start, end, 5);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(1, response.size());
+        assertEquals(50L, response.get(0).getTicketsSold());
+    }
+
+    @Test
+    void getTopRoutes_invalidDateRange_throwsException() {
+        // Arrange
+        Instant start = Instant.now();
+        Instant end = Instant.now().minusSeconds(86400); // end before start
+
+        // Act & Assert
+        assertThrows(IllegalArgumentException.class,
+                () -> adminDashboardService.getTopRoutes(start, end, 5));
+    }
+
+    @Test
+    void getRecentTransactions_success() {
+        // Arrange
+        when(bookingRepository.findRecentBookings(any(PageRequest.class)))
+                .thenReturn(Collections.singletonList(testBooking));
+
+        // Act
+        List<TransactionResponse> response = adminDashboardService.getRecentTransactions(10);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(1, response.size());
+        assertEquals("Test Passenger", response.get(0).getPassengerName());
+        assertEquals(new BigDecimal("200000"), response.get(0).getTotalPrice());
+        assertEquals(BookingStatus.CONFIRMED, response.get(0).getStatus());
+    }
+
+    @Test
+    void getTopOperators_success() {
+        // Arrange
+        Object[] row = new Object[]{testOperator, 100L, new BigDecimal("5000000")};
+        List<Object[]> data = Collections.singletonList(row);
+
+        when(bookingRepository.findTopOperators(any(PageRequest.class))).thenReturn(data);
+
+        // Act
+        List<TopOperatorResponse> response = adminDashboardService.getTopOperators(5);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(1, response.size());
+        assertEquals("VietBus", response.get(0).getOperatorName());
+        assertEquals(100L, response.get(0).getTicketsSold());
+        assertEquals(new BigDecimal("5000000"), response.get(0).getTotalRevenue());
+    }
+
+    @Test
+    void getTopOperators_withDateRange_success() {
+        // Arrange
+        Instant start = Instant.now().minusSeconds(86400 * 7);
+        Instant end = Instant.now();
+
+        Object[] row = new Object[]{testOperator, 50L, new BigDecimal("2500000")};
+        List<Object[]> data = Collections.singletonList(row);
+
+        when(bookingRepository.findTopOperatorsInRange(eq(start), eq(end), any(PageRequest.class))).thenReturn(data);
+
+        // Act
+        List<TopOperatorResponse> response = adminDashboardService.getTopOperators(start, end, 5);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(1, response.size());
+        assertEquals(50L, response.get(0).getTicketsSold());
+    }
+
+    @Test
+    void getBookingTrends_daily_success() {
+        // Arrange
+        Instant start = Instant.now().minusSeconds(86400 * 7);
+        Instant end = Instant.now();
+
+        Object[] totalRow = new Object[]{"2025-01-01", 100L};
+        Object[] confirmedRow = new Object[]{"2025-01-01", 80L};
+
+        when(bookingRepository.getBookingTrendsDaily(start, end))
+                .thenReturn(Collections.singletonList(totalRow));
+        when(bookingRepository.getConfirmedBookingTrendsDaily(start, end))
+                .thenReturn(Collections.singletonList(confirmedRow));
+
+        // Act
+        List<BookingTrendResponse> response = adminDashboardService.getBookingTrends(start, end, "day");
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(1, response.size());
+        assertEquals("2025-01-01", response.get(0).getBucket());
+        assertEquals(100L, response.get(0).getTotalBookings());
+        assertEquals(80L, response.get(0).getConfirmedBookings());
+    }
+
+    @Test
+    void getBookingTrends_weekly_success() {
+        // Arrange
+        Instant start = Instant.now().minusSeconds(86400 * 30);
+        Instant end = Instant.now();
+
+        Object[] totalRow = new Object[]{"2025-W01", 500L};
+        Object[] confirmedRow = new Object[]{"2025-W01", 400L};
+
+        when(bookingRepository.getBookingTrendsWeekly(start, end))
+                .thenReturn(Collections.singletonList(totalRow));
+        when(bookingRepository.getConfirmedBookingTrendsWeekly(start, end))
+                .thenReturn(Collections.singletonList(confirmedRow));
+
+        // Act
+        List<BookingTrendResponse> response = adminDashboardService.getBookingTrends(start, end, "week");
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(1, response.size());
+        assertEquals("2025-W01", response.get(0).getBucket());
+    }
+
+    @Test
+    void getBookingTrends_invalidGroupBy_throwsException() {
+        // Arrange
+        Instant start = Instant.now().minusSeconds(86400);
+        Instant end = Instant.now();
+
+        // Act & Assert
+        assertThrows(IllegalArgumentException.class,
+                () -> adminDashboardService.getBookingTrends(start, end, "invalid"));
+    }
+
+    @Test
+    void getBookingTrends_nullDates_throwsException() {
+        // Act & Assert
+        assertThrows(IllegalArgumentException.class,
+                () -> adminDashboardService.getBookingTrends(null, null, "day"));
+    }
+
+    @Test
+    void getBookingConversion_success() {
+        // Arrange
+        Instant start = Instant.now().minusSeconds(86400 * 7);
+        Instant end = Instant.now();
+
+        when(bookingRepository.countByCreatedAtBetween(start, end)).thenReturn(100L);
+        when(bookingRepository.countByCreatedAtBetweenAndStatus(start, end, BookingStatus.CONFIRMED)).thenReturn(80L);
+
+        // Act
+        BookingConversionResponse response = adminDashboardService.getBookingConversion(start, end);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(100L, response.getTotal());
+        assertEquals(80L, response.getConfirmed());
+        assertEquals(0.8, response.getConversionRate(), 0.001);
+    }
+
+    @Test
+    void getBookingConversion_zeroTotal_returnsZeroRate() {
+        // Arrange
+        Instant start = Instant.now().minusSeconds(86400);
+        Instant end = Instant.now();
+
+        when(bookingRepository.countByCreatedAtBetween(start, end)).thenReturn(0L);
+        when(bookingRepository.countByCreatedAtBetweenAndStatus(start, end, BookingStatus.CONFIRMED)).thenReturn(0L);
+
+        // Act
+        BookingConversionResponse response = adminDashboardService.getBookingConversion(start, end);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(0L, response.getTotal());
+        assertEquals(0.0, response.getConversionRate());
+    }
+
+    @Test
+    void getBookingConversion_invalidDateRange_throwsException() {
+        // Arrange
+        Instant start = Instant.now();
+        Instant end = Instant.now().minusSeconds(86400);
+
+        // Act & Assert
+        assertThrows(IllegalArgumentException.class,
+                () -> adminDashboardService.getBookingConversion(start, end));
+    }
+
+    @Test
+    void getTopRoutes_nullDates_usesDefault() {
+        // Arrange
+        Object[] row = new Object[]{testRoute, 100L};
+        List<Object[]> data = Collections.singletonList(row);
+
+        when(bookingRepository.findTopRoutes(any(PageRequest.class))).thenReturn(data);
+
+        // Act
+        List<TopRouteResponse> response = adminDashboardService.getTopRoutes(null, null, 5);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(1, response.size());
+    }
+
+    @Test
+    void getTopOperators_nullDates_usesDefault() {
+        // Arrange
+        Object[] row = new Object[]{testOperator, 100L, new BigDecimal("5000000")};
+        List<Object[]> data = Collections.singletonList(row);
+
+        when(bookingRepository.findTopOperators(any(PageRequest.class))).thenReturn(data);
+
+        // Act
+        List<TopOperatorResponse> response = adminDashboardService.getTopOperators(null, null, 5);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(1, response.size());
+    }
+
+    @Test
+    void getTopOperators_invalidDateRange_throwsException() {
+        // Arrange
+        Instant start = Instant.now();
+        Instant end = Instant.now().minusSeconds(86400);
+
+        // Act & Assert
+        assertThrows(IllegalArgumentException.class,
+                () -> adminDashboardService.getTopOperators(start, end, 5));
+    }
+
+    @Test
+    void getRevenueChart_nullData_handlesGracefully() {
+        // Arrange
+        Instant start = Instant.now().minusSeconds(86400 * 7);
+        Instant end = Instant.now();
+
+        when(bookingRepository.getRevenueChartData(start, end)).thenReturn(Collections.emptyList());
+
+        // Act
+        List<RevenueChartResponse> response = adminDashboardService.getRevenueChart(start, end);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(0, response.size());
+    }
+
+    @Test
+    void getRevenueChart_nullRevenue_handlesGracefully() {
+        // Arrange
+        Instant start = Instant.now().minusSeconds(86400 * 7);
+        Instant end = Instant.now();
+
+        Object[] row = new Object[]{"2025-01-01", null};
+        List<Object[]> data = Collections.singletonList(row);
+
+        when(bookingRepository.getRevenueChartData(start, end)).thenReturn(data);
+
+        // Act
+        List<RevenueChartResponse> response = adminDashboardService.getRevenueChart(start, end);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(1, response.size());
+        assertEquals(BigDecimal.ZERO, response.get(0).getRevenue());
+    }
+
+    @Test
+    void getBookingTrends_invalidDateRange_throwsException() {
+        // Arrange
+        Instant start = Instant.now();
+        Instant end = Instant.now().minusSeconds(86400);
+
+        // Act & Assert
+        assertThrows(IllegalArgumentException.class,
+                () -> adminDashboardService.getBookingTrends(start, end, "day"));
+    }
+
+    @Test
+    void getBookingTrends_defaultGroupBy() {
+        // Arrange
+        Instant start = Instant.now().minusSeconds(86400 * 7);
+        Instant end = Instant.now();
+
+        Object[] totalRow = new Object[]{"2025-01-01", 100L};
+        Object[] confirmedRow = new Object[]{"2025-01-01", 80L};
+
+        when(bookingRepository.getBookingTrendsDaily(start, end))
+                .thenReturn(Collections.singletonList(totalRow));
+        when(bookingRepository.getConfirmedBookingTrendsDaily(start, end))
+                .thenReturn(Collections.singletonList(confirmedRow));
+
+        // Act
+        List<BookingTrendResponse> response = adminDashboardService.getBookingTrends(start, end, null);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(1, response.size());
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/dashboard/service/UserDashboardServiceTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/dashboard/service/UserDashboardServiceTest.java
@@ -1,0 +1,166 @@
+package com.awad.ticketbooking.modules.dashboard.service;
+
+import com.awad.ticketbooking.common.enums.BookingStatus;
+import com.awad.ticketbooking.modules.booking.entity.Booking;
+import com.awad.ticketbooking.modules.booking.repository.BookingRepository;
+import com.awad.ticketbooking.modules.catalog.entity.Route;
+import com.awad.ticketbooking.modules.catalog.entity.Station;
+import com.awad.ticketbooking.modules.dashboard.dto.UserDashboardSummaryResponse;
+import com.awad.ticketbooking.modules.dashboard.dto.UserRecentTripResponse;
+import com.awad.ticketbooking.modules.trip.entity.Trip;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.PageRequest;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class UserDashboardServiceTest {
+
+    @InjectMocks
+    private UserDashboardService userDashboardService;
+
+    @Mock
+    private BookingRepository bookingRepository;
+
+    private String testEmail;
+    private Booking testBooking;
+
+    @BeforeEach
+    void setUp() {
+        testEmail = "test@example.com";
+
+        // Setup stations
+        Station originStation = new Station();
+        originStation.setId(UUID.randomUUID());
+        originStation.setName("Hanoi");
+        originStation.setCity("Hanoi");
+
+        Station destStation = new Station();
+        destStation.setId(UUID.randomUUID());
+        destStation.setName("Saigon");
+        destStation.setCity("Saigon");
+
+        // Setup route
+        Route route = new Route();
+        route.setId(UUID.randomUUID());
+        route.setOriginStation(originStation);
+        route.setDestinationStation(destStation);
+        route.setDistanceKm(new BigDecimal("1800"));
+
+        // Setup trip
+        Trip trip = new Trip();
+        trip.setId(UUID.randomUUID());
+        trip.setRoute(route);
+        trip.setDepartureTime(Instant.now().plusSeconds(86400));
+
+        // Setup booking
+        testBooking = new Booking();
+        testBooking.setId(UUID.randomUUID());
+        testBooking.setTrip(trip);
+        testBooking.setPassengerName("Test Passenger");
+        testBooking.setTotalPrice(new BigDecimal("200000"));
+        testBooking.setStatus(BookingStatus.CONFIRMED);
+    }
+
+    @Test
+    void getUserDashboardSummary_success() {
+        // Arrange
+        when(bookingRepository.countByUserEmail(testEmail)).thenReturn(10L);
+        when(bookingRepository.countUpcomingTripsByUser(testEmail)).thenReturn(3L);
+        when(bookingRepository.sumTotalSpentByUser(testEmail)).thenReturn(new BigDecimal("2000000"));
+
+        // Act
+        UserDashboardSummaryResponse response = userDashboardService.getUserDashboardSummary(testEmail);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(10L, response.getTotalTrips());
+        assertEquals(3L, response.getUpcomingTrips());
+        assertEquals(new BigDecimal("2000000"), response.getTotalSpent());
+    }
+
+    @Test
+    void getUserDashboardSummary_noBookings_returnsZeros() {
+        // Arrange
+        when(bookingRepository.countByUserEmail(testEmail)).thenReturn(0L);
+        when(bookingRepository.countUpcomingTripsByUser(testEmail)).thenReturn(0L);
+        when(bookingRepository.sumTotalSpentByUser(testEmail)).thenReturn(null);
+
+        // Act
+        UserDashboardSummaryResponse response = userDashboardService.getUserDashboardSummary(testEmail);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(0L, response.getTotalTrips());
+        assertEquals(0L, response.getUpcomingTrips());
+        assertEquals(BigDecimal.ZERO, response.getTotalSpent());
+    }
+
+    @Test
+    void getUserRecentTrips_success() {
+        // Arrange
+        when(bookingRepository.findRecentBookingsByUser(eq(testEmail), any(PageRequest.class)))
+                .thenReturn(Collections.singletonList(testBooking));
+
+        // Act
+        List<UserRecentTripResponse> response = userDashboardService.getUserRecentTrips(testEmail, 5);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(1, response.size());
+        assertEquals("Hanoi", response.get(0).getOrigin());
+        assertEquals("Saigon", response.get(0).getDestination());
+        assertEquals(1800.0, response.get(0).getDistance());
+        assertEquals("CONFIRMED", response.get(0).getStatus());
+    }
+
+    @Test
+    void getUserRecentTrips_noBookings_returnsEmptyList() {
+        // Arrange
+        when(bookingRepository.findRecentBookingsByUser(eq(testEmail), any(PageRequest.class)))
+                .thenReturn(Collections.emptyList());
+
+        // Act
+        List<UserRecentTripResponse> response = userDashboardService.getUserRecentTrips(testEmail, 5);
+
+        // Assert
+        assertNotNull(response);
+        assertTrue(response.isEmpty());
+    }
+
+    @Test
+    void getUserRecentTrips_multipleBookings_success() {
+        // Arrange
+        Booking booking2 = new Booking();
+        booking2.setId(UUID.randomUUID());
+        booking2.setTrip(testBooking.getTrip());
+        booking2.setStatus(BookingStatus.PENDING);
+
+        when(bookingRepository.findRecentBookingsByUser(eq(testEmail), any(PageRequest.class)))
+                .thenReturn(List.of(testBooking, booking2));
+
+        // Act
+        List<UserRecentTripResponse> response = userDashboardService.getUserRecentTrips(testEmail, 5);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(2, response.size());
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/image/controller/ImageControllerTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/image/controller/ImageControllerTest.java
@@ -1,0 +1,164 @@
+package com.awad.ticketbooking.modules.image.controller;
+
+import com.awad.ticketbooking.modules.image.dto.BatchImageUploadResponse;
+import com.awad.ticketbooking.modules.image.dto.ImageDeleteRequest;
+import com.awad.ticketbooking.modules.image.dto.ImageUploadResponse;
+import com.awad.ticketbooking.modules.image.service.ImageService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class ImageControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private ImageService imageService;
+
+    @InjectMocks
+    private ImageController imageController;
+
+    private ObjectMapper objectMapper;
+    private ImageUploadResponse mockResponse;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(imageController).build();
+        objectMapper = new ObjectMapper();
+
+        mockResponse = ImageUploadResponse.builder()
+                .url("http://cloudinary.com/image.jpg")
+                .publicId("test-id")
+                .secureUrl("https://cloudinary.com/image.jpg")
+                .bytes(1024L)
+                .format("jpg")
+                .width(800)
+                .height(600)
+                .build();
+    }
+
+    @Test
+    void uploadImage_success() throws Exception {
+        // Arrange
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "test.jpg", "image/jpeg", "test content".getBytes()
+        );
+        when(imageService.uploadImage(any(), anyString())).thenReturn(mockResponse);
+
+        // Act & Assert
+        mockMvc.perform(multipart("/api/images/upload")
+                        .file(file)
+                        .param("folder", "test-folder"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.url").value("http://cloudinary.com/image.jpg"))
+                .andExpect(jsonPath("$.publicId").value("test-id"));
+
+        verify(imageService).uploadImage(any(), eq("test-folder"));
+    }
+
+    @Test
+    void uploadImage_withoutFolder_success() throws Exception {
+        // Arrange
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "test.jpg", "image/jpeg", "test content".getBytes()
+        );
+        when(imageService.uploadImage(any(), any())).thenReturn(mockResponse);
+
+        // Act & Assert
+        mockMvc.perform(multipart("/api/images/upload")
+                        .file(file))
+                .andExpect(status().isOk());
+
+        verify(imageService).uploadImage(any(), isNull());
+    }
+
+    @Test
+    void uploadImages_success() throws Exception {
+        // Arrange
+        MockMultipartFile file1 = new MockMultipartFile(
+                "files", "test1.jpg", "image/jpeg", "content1".getBytes()
+        );
+        MockMultipartFile file2 = new MockMultipartFile(
+                "files", "test2.jpg", "image/jpeg", "content2".getBytes()
+        );
+
+        BatchImageUploadResponse batchResponse = BatchImageUploadResponse.builder()
+                .successful(List.of(mockResponse))
+                .failed(List.of())
+                .totalCount(2)
+                .successCount(2)
+                .failureCount(0)
+                .build();
+
+        when(imageService.uploadImages(any(), anyString())).thenReturn(batchResponse);
+
+        // Act & Assert
+        mockMvc.perform(multipart("/api/images/upload/batch")
+                        .file(file1)
+                        .file(file2)
+                        .param("folder", "test-folder"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalCount").value(2))
+                .andExpect(jsonPath("$.successCount").value(2));
+
+        verify(imageService).uploadImages(any(), eq("test-folder"));
+    }
+
+    @Test
+    void deleteImage_success() throws Exception {
+        // Arrange
+        ImageDeleteRequest request = new ImageDeleteRequest();
+        request.setPublicId("test-public-id");
+        doNothing().when(imageService).deleteImage(anyString());
+
+        // Act & Assert
+        mockMvc.perform(delete("/api/images")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent());
+
+        verify(imageService).deleteImage("test-public-id");
+    }
+
+    @Test
+    void deleteImages_success() throws Exception {
+        // Arrange
+        List<String> publicIds = List.of("id1", "id2", "id3");
+        Map<String, Boolean> deleteResults = new HashMap<>();
+        deleteResults.put("id1", true);
+        deleteResults.put("id2", true);
+        deleteResults.put("id3", false);
+
+        when(imageService.deleteImages(anyList())).thenReturn(deleteResults);
+
+        // Act & Assert
+        mockMvc.perform(delete("/api/images/batch")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(publicIds)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id1").value(true))
+                .andExpect(jsonPath("$.id2").value(true))
+                .andExpect(jsonPath("$.id3").value(false));
+
+        verify(imageService).deleteImages(publicIds);
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/image/service/ImageServiceTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/image/service/ImageServiceTest.java
@@ -1,0 +1,477 @@
+package com.awad.ticketbooking.modules.image.service;
+
+import com.awad.ticketbooking.common.exception.ImageUploadException;
+import com.awad.ticketbooking.modules.image.dto.BatchImageUploadResponse;
+import com.awad.ticketbooking.modules.image.dto.ImageUploadResponse;
+import com.cloudinary.Cloudinary;
+import com.cloudinary.Uploader;
+import com.cloudinary.utils.ObjectUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ImageServiceTest {
+
+    @InjectMocks
+    private ImageService imageService;
+
+    @Mock
+    private Cloudinary cloudinary;
+
+    @Mock
+    private Uploader uploader;
+
+    private MockMultipartFile validImageFile;
+    private MockMultipartFile invalidTypeFile;
+    private MockMultipartFile tooLargeFile;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(imageService, "maxBatchSizeMB", 50L);
+        ReflectionTestUtils.setField(imageService, "maxBatchFiles", 20);
+
+        when(cloudinary.uploader()).thenReturn(uploader);
+
+        // Valid image file (JPEG, 1MB)
+        byte[] imageBytes = new byte[1024 * 1024]; // 1MB
+        validImageFile = new MockMultipartFile(
+                "file",
+                "test.jpg",
+                "image/jpeg",
+                imageBytes
+        );
+
+        // Invalid type file
+        invalidTypeFile = new MockMultipartFile(
+                "file",
+                "test.pdf",
+                "application/pdf",
+                "content".getBytes()
+        );
+
+        // Too large file (6MB)
+        byte[] largeBytes = new byte[6 * 1024 * 1024];
+        tooLargeFile = new MockMultipartFile(
+                "file",
+                "large.jpg",
+                "image/jpeg",
+                largeBytes
+        );
+    }
+
+    @Test
+    void uploadImage_success() throws Exception {
+        // Arrange
+        Map<String, Object> uploadResult = new HashMap<>();
+        uploadResult.put("url", "http://cloudinary.com/image.jpg");
+        uploadResult.put("public_id", "test-id");
+        uploadResult.put("secure_url", "https://cloudinary.com/image.jpg");
+        uploadResult.put("bytes", 1024L);
+        uploadResult.put("format", "jpg");
+        uploadResult.put("width", 800);
+        uploadResult.put("height", 600);
+
+        when(uploader.upload(any(byte[].class), any(Map.class))).thenReturn(uploadResult);
+
+        // Act
+        ImageUploadResponse response = imageService.uploadImage(validImageFile, "test-folder");
+
+        // Assert
+        assertNotNull(response);
+        assertEquals("http://cloudinary.com/image.jpg", response.getUrl());
+        assertEquals("test-id", response.getPublicId());
+        assertEquals("https://cloudinary.com/image.jpg", response.getSecureUrl());
+        assertEquals(1024L, response.getBytes());
+        assertEquals("jpg", response.getFormat());
+        assertEquals(800, response.getWidth());
+        assertEquals(600, response.getHeight());
+        verify(uploader).upload(any(byte[].class), any(Map.class));
+    }
+
+    @Test
+    void uploadImage_withNullFolder_success() throws Exception {
+        // Arrange
+        Map<String, Object> uploadResult = new HashMap<>();
+        uploadResult.put("url", "http://cloudinary.com/image.jpg");
+        uploadResult.put("public_id", "test-id");
+        uploadResult.put("secure_url", "https://cloudinary.com/image.jpg");
+        uploadResult.put("bytes", 1024L);
+        uploadResult.put("format", "jpg");
+        uploadResult.put("width", 800);
+        uploadResult.put("height", 600);
+
+        when(uploader.upload(any(byte[].class), any(Map.class))).thenReturn(uploadResult);
+
+        // Act
+        ImageUploadResponse response = imageService.uploadImage(validImageFile, null);
+
+        // Assert
+        assertNotNull(response);
+        verify(uploader).upload(any(byte[].class), any(Map.class));
+    }
+
+    @Test
+    void uploadImage_withEmptyFolder_success() throws Exception {
+        // Arrange
+        Map<String, Object> uploadResult = new HashMap<>();
+        uploadResult.put("url", "http://cloudinary.com/image.jpg");
+        uploadResult.put("public_id", "test-id");
+        uploadResult.put("secure_url", "https://cloudinary.com/image.jpg");
+        uploadResult.put("bytes", 1024L);
+        uploadResult.put("format", "jpg");
+        uploadResult.put("width", 800);
+        uploadResult.put("height", 600);
+
+        when(uploader.upload(any(byte[].class), any(Map.class))).thenReturn(uploadResult);
+
+        // Act
+        ImageUploadResponse response = imageService.uploadImage(validImageFile, "");
+
+        // Assert
+        assertNotNull(response);
+        verify(uploader).upload(any(byte[].class), any(Map.class));
+    }
+
+    @Test
+    void uploadImage_nullFile_throwsException() {
+        // Act & Assert
+        assertThrows(ImageUploadException.class, () -> {
+            imageService.uploadImage(null, "folder");
+        });
+    }
+
+    @Test
+    void uploadImage_emptyFile_throwsException() {
+        // Arrange
+        MockMultipartFile emptyFile = new MockMultipartFile("file", "test.jpg", "image/jpeg", new byte[0]);
+
+        // Act & Assert
+        assertThrows(ImageUploadException.class, () -> {
+            imageService.uploadImage(emptyFile, "folder");
+        });
+    }
+
+    @Test
+    void uploadImage_invalidContentType_throwsException() {
+        // Act & Assert
+        assertThrows(ImageUploadException.class, () -> {
+            imageService.uploadImage(invalidTypeFile, "folder");
+        });
+    }
+
+    @Test
+    void uploadImage_tooLargeFile_throwsException() {
+        // Act & Assert
+        assertThrows(ImageUploadException.class, () -> {
+            imageService.uploadImage(tooLargeFile, "folder");
+        });
+    }
+
+    @Test
+    void uploadImage_ioException_throwsException() throws Exception {
+        // Arrange
+        when(uploader.upload(any(byte[].class), any(Map.class)))
+                .thenThrow(new IOException("Network error"));
+
+        // Act & Assert
+        assertThrows(ImageUploadException.class, () -> {
+            imageService.uploadImage(validImageFile, "folder");
+        });
+    }
+
+    @Test
+    void uploadImage_cloudinaryException_throwsException() throws Exception {
+        // Arrange
+        when(uploader.upload(any(byte[].class), any(Map.class)))
+                .thenThrow(new RuntimeException("Cloudinary error"));
+
+        // Act & Assert
+        assertThrows(ImageUploadException.class, () -> {
+            imageService.uploadImage(validImageFile, "folder");
+        });
+    }
+
+    @Test
+    void uploadImages_success() throws Exception {
+        // Arrange
+        Map<String, Object> uploadResult = new HashMap<>();
+        uploadResult.put("url", "http://cloudinary.com/image.jpg");
+        uploadResult.put("public_id", "test-id");
+        uploadResult.put("secure_url", "https://cloudinary.com/image.jpg");
+        uploadResult.put("bytes", 1024L);
+        uploadResult.put("format", "jpg");
+        uploadResult.put("width", 800);
+        uploadResult.put("height", 600);
+
+        when(uploader.upload(any(byte[].class), any(Map.class))).thenReturn(uploadResult);
+
+        MockMultipartFile file1 = new MockMultipartFile("file1", "test1.jpg", "image/jpeg", new byte[1024]);
+        MockMultipartFile file2 = new MockMultipartFile("file2", "test2.jpg", "image/jpeg", new byte[1024]);
+
+        // Act
+        BatchImageUploadResponse response = imageService.uploadImages(
+                new MultipartFile[]{file1, file2},
+                "test-folder"
+        );
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(2, response.getTotalCount());
+        assertEquals(2, response.getSuccessCount());
+        assertEquals(0, response.getFailureCount());
+        assertEquals(2, response.getSuccessful().size());
+        assertTrue(response.getFailed().isEmpty());
+    }
+
+    @Test
+    void uploadImages_nullFiles_throwsException() {
+        // Act & Assert
+        assertThrows(ImageUploadException.class, () -> {
+            imageService.uploadImages(null, "folder");
+        });
+    }
+
+    @Test
+    void uploadImages_emptyArray_throwsException() {
+        // Act & Assert
+        assertThrows(ImageUploadException.class, () -> {
+            imageService.uploadImages(new MultipartFile[0], "folder");
+        });
+    }
+
+    @Test
+    void uploadImages_tooManyFiles_throwsException() {
+        // Arrange
+        MultipartFile[] files = new MultipartFile[21]; // Exceeds maxBatchFiles (20)
+        for (int i = 0; i < 21; i++) {
+            files[i] = validImageFile;
+        }
+
+        // Act & Assert
+        assertThrows(ImageUploadException.class, () -> {
+            imageService.uploadImages(files, "folder");
+        });
+    }
+
+    @Test
+    void uploadImages_withSomeFailures_returnsPartialSuccess() throws Exception {
+        // Arrange
+        Map<String, Object> uploadResult = new HashMap<>();
+        uploadResult.put("url", "http://cloudinary.com/image.jpg");
+        uploadResult.put("public_id", "test-id");
+        uploadResult.put("secure_url", "https://cloudinary.com/image.jpg");
+        uploadResult.put("bytes", 1024L);
+        uploadResult.put("format", "jpg");
+        uploadResult.put("width", 800);
+        uploadResult.put("height", 600);
+
+        when(uploader.upload(any(byte[].class), any(Map.class)))
+                .thenReturn(uploadResult)
+                .thenThrow(new RuntimeException("Upload failed"));
+
+        MockMultipartFile file1 = new MockMultipartFile("file1", "test1.jpg", "image/jpeg", new byte[1024]);
+        MockMultipartFile file2 = new MockMultipartFile("file2", "test2.jpg", "image/jpeg", new byte[1024]);
+
+        // Act
+        BatchImageUploadResponse response = imageService.uploadImages(
+                new MultipartFile[]{file1, file2},
+                "test-folder"
+        );
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(2, response.getTotalCount());
+        assertEquals(1, response.getSuccessCount());
+        assertEquals(1, response.getFailureCount());
+        assertEquals(1, response.getSuccessful().size());
+        assertEquals(1, response.getFailed().size());
+    }
+
+    @Test
+    void uploadImages_withNullFilesInArray_skipsNullFiles() throws Exception {
+        // Arrange
+        Map<String, Object> uploadResult = new HashMap<>();
+        uploadResult.put("url", "http://cloudinary.com/image.jpg");
+        uploadResult.put("public_id", "test-id");
+        uploadResult.put("secure_url", "https://cloudinary.com/image.jpg");
+        uploadResult.put("bytes", 1024L);
+        uploadResult.put("format", "jpg");
+        uploadResult.put("width", 800);
+        uploadResult.put("height", 600);
+
+        when(uploader.upload(any(byte[].class), any(Map.class))).thenReturn(uploadResult);
+
+        MockMultipartFile file1 = new MockMultipartFile("file1", "test1.jpg", "image/jpeg", new byte[1024]);
+
+        // Act
+        BatchImageUploadResponse response = imageService.uploadImages(
+                new MultipartFile[]{file1, null},
+                "test-folder"
+        );
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(2, response.getTotalCount());
+        assertEquals(1, response.getSuccessCount());
+        assertEquals(0, response.getFailureCount());
+    }
+
+    @Test
+    void deleteImage_success() throws Exception {
+        // Arrange
+        Map<String, Object> deleteResult = new HashMap<>();
+        deleteResult.put("result", "ok");
+
+        when(uploader.destroy(eq("test-public-id"), any(Map.class))).thenReturn(deleteResult);
+
+        // Act
+        imageService.deleteImage("test-public-id");
+
+        // Assert
+        verify(uploader).destroy(eq("test-public-id"), any(Map.class));
+    }
+
+    @Test
+    void deleteImage_failure_throwsException() throws Exception {
+        // Arrange
+        Map<String, Object> deleteResult = new HashMap<>();
+        deleteResult.put("result", "not found");
+
+        when(uploader.destroy(eq("test-public-id"), any(Map.class))).thenReturn(deleteResult);
+
+        // Act & Assert
+        assertThrows(ImageUploadException.class, () -> {
+            imageService.deleteImage("test-public-id");
+        });
+    }
+
+    @Test
+    void deleteImage_ioException_throwsException() throws Exception {
+        // Arrange
+        when(uploader.destroy(eq("test-public-id"), any(Map.class)))
+                .thenThrow(new IOException("Network error"));
+
+        // Act & Assert
+        assertThrows(ImageUploadException.class, () -> {
+            imageService.deleteImage("test-public-id");
+        });
+    }
+
+    @Test
+    void deleteImages_success() throws Exception {
+        // Arrange
+        Map<String, Object> deleteResult = new HashMap<>();
+        deleteResult.put("result", "ok");
+
+        when(uploader.destroy(anyString(), any(Map.class))).thenReturn(deleteResult);
+
+        // Act
+        Map<String, Boolean> results = imageService.deleteImages(List.of("id1", "id2", "id3"));
+
+        // Assert
+        assertNotNull(results);
+        assertEquals(3, results.size());
+        assertTrue(results.get("id1"));
+        assertTrue(results.get("id2"));
+        assertTrue(results.get("id3"));
+    }
+
+    @Test
+    void deleteImages_withSomeFailures_returnsPartialResults() throws Exception {
+        // Arrange
+        Map<String, Object> successResult = new HashMap<>();
+        successResult.put("result", "ok");
+
+        Map<String, Object> failureResult = new HashMap<>();
+        failureResult.put("result", "not found");
+
+        when(uploader.destroy(eq("id1"), any(Map.class))).thenReturn(successResult);
+        when(uploader.destroy(eq("id2"), any(Map.class))).thenReturn(failureResult);
+
+        // Act
+        Map<String, Boolean> results = imageService.deleteImages(List.of("id1", "id2"));
+
+        // Assert
+        assertNotNull(results);
+        assertEquals(2, results.size());
+        assertTrue(results.get("id1"));
+        assertFalse(results.get("id2"));
+    }
+
+    @Test
+    void uploadImage_withPngFile_success() throws Exception {
+        // Arrange
+        MockMultipartFile pngFile = new MockMultipartFile(
+                "file",
+                "test.png",
+                "image/png",
+                new byte[1024]
+        );
+
+        Map<String, Object> uploadResult = new HashMap<>();
+        uploadResult.put("url", "http://cloudinary.com/image.png");
+        uploadResult.put("public_id", "test-id");
+        uploadResult.put("secure_url", "https://cloudinary.com/image.png");
+        uploadResult.put("bytes", 1024L);
+        uploadResult.put("format", "png");
+        uploadResult.put("width", 800);
+        uploadResult.put("height", 600);
+
+        when(uploader.upload(any(byte[].class), any(Map.class))).thenReturn(uploadResult);
+
+        // Act
+        ImageUploadResponse response = imageService.uploadImage(pngFile, "test-folder");
+
+        // Assert
+        assertNotNull(response);
+        assertEquals("png", response.getFormat());
+    }
+
+    @Test
+    void uploadImage_withWebpFile_success() throws Exception {
+        // Arrange
+        MockMultipartFile webpFile = new MockMultipartFile(
+                "file",
+                "test.webp",
+                "image/webp",
+                new byte[1024]
+        );
+
+        Map<String, Object> uploadResult = new HashMap<>();
+        uploadResult.put("url", "http://cloudinary.com/image.webp");
+        uploadResult.put("public_id", "test-id");
+        uploadResult.put("secure_url", "https://cloudinary.com/image.webp");
+        uploadResult.put("bytes", 1024L);
+        uploadResult.put("format", "webp");
+        uploadResult.put("width", 800);
+        uploadResult.put("height", 600);
+
+        when(uploader.upload(any(byte[].class), any(Map.class))).thenReturn(uploadResult);
+
+        // Act
+        ImageUploadResponse response = imageService.uploadImage(webpFile, "test-folder");
+
+        // Assert
+        assertNotNull(response);
+        assertEquals("webp", response.getFormat());
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/payment/controller/PaymentControllerTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/payment/controller/PaymentControllerTest.java
@@ -1,0 +1,118 @@
+package com.awad.ticketbooking.modules.payment.controller;
+
+import com.awad.ticketbooking.modules.payment.dto.CreatePaymentRequest;
+import com.awad.ticketbooking.modules.payment.dto.PaymentResponse;
+import com.awad.ticketbooking.modules.payment.service.PaymentService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.awad.ticketbooking.common.enums.PaymentStatus;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private PaymentService paymentService;
+
+    @InjectMocks
+    private PaymentController paymentController;
+
+    private ObjectMapper objectMapper;
+    private PaymentResponse mockPaymentResponse;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(paymentController).build();
+        objectMapper = new ObjectMapper();
+
+        mockPaymentResponse = PaymentResponse.builder()
+                .id(UUID.randomUUID())
+                .bookingId(UUID.randomUUID())
+                .amount(new BigDecimal("200000"))
+                .status(PaymentStatus.PENDING)
+                .build();
+    }
+
+    @Test
+    void createPayment_success() throws Exception {
+        // Arrange
+        CreatePaymentRequest request = new CreatePaymentRequest();
+        request.setBookingId(mockPaymentResponse.getBookingId());
+        request.setReturnUrl("https://example.com/return");
+        request.setCancelUrl("https://example.com/cancel");
+        when(paymentService.createPayment(any(CreatePaymentRequest.class))).thenReturn(mockPaymentResponse);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/payments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("PENDING"));
+
+        verify(paymentService).createPayment(any(CreatePaymentRequest.class));
+    }
+
+    @Test
+    void getPayment_success() throws Exception {
+        // Arrange
+        UUID paymentId = mockPaymentResponse.getId();
+        when(paymentService.getPaymentById(paymentId)).thenReturn(mockPaymentResponse);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/payments/{id}", paymentId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(paymentId.toString()));
+
+        verify(paymentService).getPaymentById(paymentId);
+    }
+
+    @Test
+    void getPaymentByBooking_success() throws Exception {
+        // Arrange
+        UUID bookingId = mockPaymentResponse.getBookingId();
+        when(paymentService.getPaymentByBookingId(bookingId)).thenReturn(mockPaymentResponse);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/payments/booking/{bookingId}", bookingId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.bookingId").value(bookingId.toString()));
+
+        verify(paymentService).getPaymentByBookingId(bookingId);
+    }
+
+    @Test
+    void verifyPayment_success() throws Exception {
+        // Arrange
+        UUID bookingId = UUID.randomUUID();
+        PaymentResponse verifiedResponse = PaymentResponse.builder()
+                .id(UUID.randomUUID())
+                .bookingId(bookingId)
+                .status(PaymentStatus.SUCCESS)
+                .build();
+        when(paymentService.verifyAndUpdatePayment(bookingId)).thenReturn(verifiedResponse);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/payments/verify/{bookingId}", bookingId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+
+        verify(paymentService).verifyAndUpdatePayment(bookingId);
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/payment/controller/PaymentWebhookControllerTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/payment/controller/PaymentWebhookControllerTest.java
@@ -1,0 +1,66 @@
+package com.awad.ticketbooking.modules.payment.controller;
+
+import com.awad.ticketbooking.modules.payment.service.PaymentService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentWebhookControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private PaymentService paymentService;
+
+    @InjectMocks
+    private PaymentWebhookController paymentWebhookController;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(paymentWebhookController).build();
+    }
+
+    @Test
+    void handleWebhook_success() throws Exception {
+        // Arrange
+        String webhookBody = "{\"code\": 0, \"data\": {}}";
+        doNothing().when(paymentService).handleWebhook(anyString());
+
+        // Act & Assert
+        mockMvc.perform(post("/api/webhooks/payos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(webhookBody))
+                .andExpect(status().isOk())
+                .andExpect(content().string("OK"));
+
+        verify(paymentService).handleWebhook(anyString());
+    }
+
+    @Test
+    void handleWebhook_withException() throws Exception {
+        // Arrange
+        String webhookBody = "{\"code\": 0, \"data\": {}}";
+        doThrow(new RuntimeException("Webhook error")).when(paymentService).handleWebhook(anyString());
+
+        // Act & Assert
+        mockMvc.perform(post("/api/webhooks/payos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(webhookBody))
+                .andExpect(status().isOk())
+                .andExpect(content().string("RECEIVED"));
+
+        verify(paymentService).handleWebhook(anyString());
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/payment/service/PaymentServiceTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/payment/service/PaymentServiceTest.java
@@ -1,0 +1,334 @@
+package com.awad.ticketbooking.modules.payment.service;
+
+import com.awad.ticketbooking.common.enums.BookingStatus;
+import com.awad.ticketbooking.common.enums.PaymentStatus;
+import com.awad.ticketbooking.common.service.EmailService;
+import com.awad.ticketbooking.modules.auth.entity.User;
+import com.awad.ticketbooking.modules.booking.entity.Booking;
+import com.awad.ticketbooking.modules.booking.entity.Ticket;
+import com.awad.ticketbooking.modules.booking.repository.BookingRepository;
+import com.awad.ticketbooking.modules.booking.repository.TicketRepository;
+import com.awad.ticketbooking.modules.booking.service.SeatLockService;
+import com.awad.ticketbooking.modules.catalog.entity.Bus;
+import com.awad.ticketbooking.modules.catalog.entity.BusLayout;
+import com.awad.ticketbooking.modules.catalog.entity.Operator;
+import com.awad.ticketbooking.modules.catalog.entity.Route;
+import com.awad.ticketbooking.modules.catalog.entity.Station;
+import com.awad.ticketbooking.modules.payment.dto.CreatePaymentRequest;
+import com.awad.ticketbooking.modules.payment.dto.PaymentResponse;
+import com.awad.ticketbooking.modules.payment.entity.PaymentTransaction;
+import com.awad.ticketbooking.modules.payment.repository.PaymentTransactionRepository;
+import com.awad.ticketbooking.modules.payment.repository.PaymentWebhookEventRepository;
+import com.awad.ticketbooking.modules.trip.entity.Trip;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import vn.payos.PayOS;
+import vn.payos.model.v2.paymentRequests.CreatePaymentLinkResponse;
+import vn.payos.model.v2.paymentRequests.PaymentLinkStatus;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PaymentServiceTest {
+
+    @InjectMocks
+    private PaymentService paymentService;
+
+    @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
+    private PayOS payOS;
+
+    @Mock
+    private PaymentTransactionRepository paymentTransactionRepository;
+
+    @Mock
+    private PaymentWebhookEventRepository webhookEventRepository;
+
+    @Mock
+    private BookingRepository bookingRepository;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private EmailService emailService;
+
+    @Mock
+    private TicketRepository ticketRepository;
+
+    @Mock
+    private SeatLockService seatLockService;
+
+    private Booking testBooking;
+    private PaymentTransaction testTransaction;
+    private Trip testTrip;
+
+    @BeforeEach
+    void setUp() {
+        // Setup station
+        Station originStation = new Station();
+        originStation.setId(UUID.randomUUID());
+        originStation.setName("Hanoi");
+        originStation.setCity("Hanoi");
+        originStation.setAddress("123 Main St");
+
+        Station destStation = new Station();
+        destStation.setId(UUID.randomUUID());
+        destStation.setName("Saigon");
+        destStation.setCity("Saigon");
+        destStation.setAddress("456 Main St");
+
+        // Setup route
+        Route route = new Route();
+        route.setId(UUID.randomUUID());
+        route.setOriginStation(originStation);
+        route.setDestinationStation(destStation);
+        route.setDurationMinutes(360);
+
+        // Setup operator and bus
+        Operator operator = new Operator();
+        operator.setId(UUID.randomUUID());
+        operator.setName("VietBus");
+
+        BusLayout layout = new BusLayout();
+        layout.setId(UUID.randomUUID());
+        layout.setTotalSeats(40);
+
+        Bus bus = new Bus();
+        bus.setId(UUID.randomUUID());
+        bus.setPlateNumber("29A-12345");
+        bus.setOperator(operator);
+        bus.setBusLayout(layout);
+        bus.setAmenities(Collections.singletonList("wifi"));
+
+        // Setup trip
+        testTrip = new Trip();
+        testTrip.setId(UUID.randomUUID());
+        testTrip.setRoute(route);
+        testTrip.setBus(bus);
+        testTrip.setDepartureTime(Instant.now().plusSeconds(86400));
+        testTrip.setArrivalTime(Instant.now().plusSeconds(108000));
+
+        // Setup user
+        User user = User.builder()
+                .email("test@example.com")
+                .fullName("Test User")
+                .build();
+        user.setId(UUID.randomUUID());
+
+        // Setup booking
+        testBooking = new Booking();
+        testBooking.setId(UUID.randomUUID());
+        testBooking.setCode("BK-ABC123");
+        testBooking.setTrip(testTrip);
+        testBooking.setUser(user);
+        testBooking.setPassengerName("Test Passenger");
+        testBooking.setPassengerPhone("0123456789");
+        testBooking.setPassengerEmail("test@example.com");
+        testBooking.setStatus(BookingStatus.PENDING);
+        testBooking.setTotalPrice(new BigDecimal("200000"));
+        testBooking.setPickupStation(originStation);
+        testBooking.setDropoffStation(destStation);
+
+        Ticket ticket = new Ticket();
+        ticket.setId(UUID.randomUUID());
+        ticket.setBooking(testBooking);
+        ticket.setSeatCode("A1");
+        ticket.setPassengerName("Test Passenger");
+        ticket.setPassengerPhone("0123456789");
+        ticket.setPrice(new BigDecimal("200000"));
+        testBooking.setTickets(new ArrayList<>(Collections.singletonList(ticket)));
+
+        // Setup payment transaction
+        testTransaction = new PaymentTransaction();
+        testTransaction.setId(UUID.randomUUID());
+        testTransaction.setBooking(testBooking);
+        testTransaction.setOrderCode(System.currentTimeMillis());
+        testTransaction.setAmount(new BigDecimal("200000"));
+        testTransaction.setStatus(PaymentStatus.PENDING);
+        testTransaction.setPaymentLinkId("pl_123");
+        testTransaction.setCheckoutUrl("https://pay.payos.vn/web/123");
+        testTransaction.setQrCode("qr_data");
+    }
+
+    @Test
+    void createPayment_success() throws Exception {
+        // Arrange
+        CreatePaymentRequest request = new CreatePaymentRequest();
+        request.setBookingId(testBooking.getId());
+        request.setReturnUrl("https://example.com/return");
+        request.setCancelUrl("https://example.com/cancel");
+
+        CreatePaymentLinkResponse payosResponse = CreatePaymentLinkResponse.builder()
+                .paymentLinkId("pl_123")
+                .checkoutUrl("https://pay.payos.vn/web/123")
+                .qrCode("qr_data")
+                .bin("970415")
+                .accountNumber("1234567890")
+                .accountName("Test Account")
+                .amount(100000L)
+                .description("Test payment")
+                .orderCode(12345L)
+                .currency("VND")
+                .status(PaymentLinkStatus.PENDING)
+                .build();
+
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+        when(paymentTransactionRepository.findByBookingId(testBooking.getId())).thenReturn(Optional.empty());
+        when(paymentTransactionRepository.existsByOrderCode(anyLong())).thenReturn(false);
+        when(payOS.paymentRequests().create(any())).thenReturn(payosResponse);
+        when(paymentTransactionRepository.save(any(PaymentTransaction.class))).thenReturn(testTransaction);
+
+        // Act
+        PaymentResponse response = paymentService.createPayment(request);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(testBooking.getId(), response.getBookingId());
+        assertNotNull(response.getCheckoutUrl());
+        verify(paymentTransactionRepository).save(any(PaymentTransaction.class));
+    }
+
+    @Test
+    void createPayment_bookingNotFound_throwsException() {
+        // Arrange
+        CreatePaymentRequest request = new CreatePaymentRequest();
+        request.setBookingId(UUID.randomUUID());
+
+        when(bookingRepository.findById(request.getBookingId())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> paymentService.createPayment(request));
+        assertEquals("Booking not found", exception.getMessage());
+    }
+
+    @Test
+    void createPayment_bookingNotPending_throwsException() {
+        // Arrange
+        testBooking.setStatus(BookingStatus.CONFIRMED);
+        CreatePaymentRequest request = new CreatePaymentRequest();
+        request.setBookingId(testBooking.getId());
+
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> paymentService.createPayment(request));
+        assertTrue(exception.getMessage().contains("Only pending bookings can be paid"));
+    }
+
+    @Test
+    void createPayment_paymentAlreadyExists_throwsException() {
+        // Arrange
+        CreatePaymentRequest request = new CreatePaymentRequest();
+        request.setBookingId(testBooking.getId());
+
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+        when(paymentTransactionRepository.findByBookingId(testBooking.getId()))
+                .thenReturn(Optional.of(testTransaction));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> paymentService.createPayment(request));
+        assertEquals("Payment already exists for this booking", exception.getMessage());
+    }
+
+    @Test
+    void getPaymentByBookingId_success() {
+        // Arrange
+        when(paymentTransactionRepository.findByBookingId(testBooking.getId()))
+                .thenReturn(Optional.of(testTransaction));
+
+        // Act
+        PaymentResponse response = paymentService.getPaymentByBookingId(testBooking.getId());
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(testBooking.getId(), response.getBookingId());
+        assertEquals(PaymentStatus.PENDING, response.getStatus());
+    }
+
+    @Test
+    void getPaymentByBookingId_notFound_throwsException() {
+        // Arrange
+        UUID nonExistentId = UUID.randomUUID();
+        when(paymentTransactionRepository.findByBookingId(nonExistentId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> paymentService.getPaymentByBookingId(nonExistentId));
+        assertTrue(exception.getMessage().contains("Payment not found"));
+    }
+
+    @Test
+    void getPaymentById_success() {
+        // Arrange
+        when(paymentTransactionRepository.findById(testTransaction.getId()))
+                .thenReturn(Optional.of(testTransaction));
+
+        // Act
+        PaymentResponse response = paymentService.getPaymentById(testTransaction.getId());
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(testTransaction.getId(), response.getId());
+    }
+
+    @Test
+    void getPaymentById_notFound_throwsException() {
+        // Arrange
+        UUID nonExistentId = UUID.randomUUID();
+        when(paymentTransactionRepository.findById(nonExistentId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> paymentService.getPaymentById(nonExistentId));
+        assertTrue(exception.getMessage().contains("Payment not found"));
+    }
+
+    @Test
+    void verifyAndUpdatePayment_alreadySuccess_returnsWithoutUpdate() throws Exception {
+        // Arrange
+        testTransaction.setStatus(PaymentStatus.SUCCESS);
+        when(paymentTransactionRepository.findByBookingId(testBooking.getId()))
+                .thenReturn(Optional.of(testTransaction));
+
+        // Act
+        PaymentResponse response = paymentService.verifyAndUpdatePayment(testBooking.getId());
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(PaymentStatus.SUCCESS, response.getStatus());
+        verify(payOS, never()).paymentRequests();
+    }
+
+    @Test
+    void verifyAndUpdatePayment_notFound_throwsException() {
+        // Arrange
+        UUID nonExistentId = UUID.randomUUID();
+        when(paymentTransactionRepository.findByBookingId(nonExistentId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> paymentService.verifyAndUpdatePayment(nonExistentId));
+        assertTrue(exception.getMessage().contains("Payment not found"));
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/review/controller/ReviewControllerTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/review/controller/ReviewControllerTest.java
@@ -1,0 +1,200 @@
+package com.awad.ticketbooking.modules.review.controller;
+
+import com.awad.ticketbooking.common.config.security.ApplicationUserDetails;
+import com.awad.ticketbooking.common.model.ApiResponse;
+import com.awad.ticketbooking.modules.auth.entity.User;
+import com.awad.ticketbooking.modules.auth.entity.UserRole;
+import com.awad.ticketbooking.modules.review.dto.CreateReviewRequest;
+import com.awad.ticketbooking.modules.review.dto.OperatorStatsResponse;
+import com.awad.ticketbooking.modules.review.dto.ReviewResponse;
+import com.awad.ticketbooking.modules.review.service.ReviewService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private ReviewService reviewService;
+
+    @InjectMocks
+    private ReviewController reviewController;
+
+    private ObjectMapper objectMapper;
+    private ReviewResponse mockReviewResponse;
+    private User testUser;
+    private ApplicationUserDetails userDetails;
+
+    @BeforeEach
+    void setUp() {
+        PageableHandlerMethodArgumentResolver pageableResolver = new PageableHandlerMethodArgumentResolver();
+        pageableResolver.setFallbackPageable(PageRequest.of(0, 20));
+        AuthenticationPrincipalArgumentResolver authResolver = new AuthenticationPrincipalArgumentResolver();
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+        objectMapper.disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        org.springframework.http.converter.json.MappingJackson2HttpMessageConverter converter = 
+                new org.springframework.http.converter.json.MappingJackson2HttpMessageConverter(objectMapper);
+        mockMvc = MockMvcBuilders.standaloneSetup(reviewController)
+                .setCustomArgumentResolvers(pageableResolver, authResolver)
+                .setMessageConverters(converter)
+                .build();
+
+        testUser = new User();
+        testUser.setId(UUID.randomUUID());
+        testUser.setEmail("test@example.com");
+        testUser.setRole(UserRole.PASSENGER);
+        userDetails = new ApplicationUserDetails(testUser);
+
+        mockReviewResponse = ReviewResponse.builder()
+                .id(UUID.randomUUID())
+                .rating(5)
+                .comment("Great trip!")
+                .build();
+    }
+    
+    private void setupSecurityContext() {
+        SecurityContext context = new SecurityContextImpl();
+        Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        context.setAuthentication(auth);
+        SecurityContextHolder.setContext(context);
+    }
+    
+    private void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void createReview_success() throws Exception {
+        try {
+            setupSecurityContext();
+            // Arrange
+            CreateReviewRequest request = new CreateReviewRequest();
+            request.setBookingId(UUID.randomUUID());
+            request.setRating(5);
+            request.setComment("Great trip!");
+            when(reviewService.createReview(any(CreateReviewRequest.class), any(UUID.class)))
+                    .thenReturn(mockReviewResponse);
+
+            // Act & Assert
+            mockMvc.perform(post("/api/reviews")
+                            .with(SecurityMockMvcRequestPostProcessors.user(userDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.rating").value(5));
+
+            verify(reviewService).createReview(any(CreateReviewRequest.class), any(UUID.class));
+        } finally {
+            clearSecurityContext();
+        }
+    }
+
+    @Test
+    void createReview_unauthorized() throws Exception {
+        // Arrange
+        CreateReviewRequest request = new CreateReviewRequest();
+        request.setBookingId(UUID.randomUUID());
+        request.setRating(5);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/reviews")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getReviewsByOperator_success() throws Exception {
+        // Arrange
+        UUID operatorId = UUID.randomUUID();
+        Page<ReviewResponse> page = new PageImpl<>(Arrays.asList(mockReviewResponse), PageRequest.of(0, 10), 1);
+        when(reviewService.getReviewsByOperator(operatorId, PageRequest.of(0, 10)))
+                .thenReturn(page);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/reviews/operator/{operatorId}", operatorId)
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].rating").value(5));
+
+        verify(reviewService).getReviewsByOperator(eq(operatorId), any());
+    }
+
+    @Test
+    void getOperatorStats_success() throws Exception {
+        // Arrange
+        UUID operatorId = UUID.randomUUID();
+        OperatorStatsResponse stats = OperatorStatsResponse.builder()
+                .averageRating(4.5)
+                .totalReviews(10L)
+                .build();
+        when(reviewService.getOperatorStats(operatorId)).thenReturn(stats);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/reviews/operator/{operatorId}/stats", operatorId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.averageRating").value(4.5))
+                .andExpect(jsonPath("$.data.totalReviews").value(10));
+
+        verify(reviewService).getOperatorStats(operatorId);
+    }
+
+    @Test
+    void getReviewByBookingId_success() throws Exception {
+        // Arrange
+        UUID bookingId = UUID.randomUUID();
+        when(reviewService.getReviewByBookingId(bookingId)).thenReturn(mockReviewResponse);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/reviews/booking/{bookingId}", bookingId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.rating").value(5));
+
+        verify(reviewService).getReviewByBookingId(bookingId);
+    }
+
+    @Test
+    void getReviewByBookingId_notFound() throws Exception {
+        // Arrange
+        UUID bookingId = UUID.randomUUID();
+        when(reviewService.getReviewByBookingId(bookingId)).thenReturn(null);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/reviews/booking/{bookingId}", bookingId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404));
+
+        verify(reviewService).getReviewByBookingId(bookingId);
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/review/service/ReviewServiceTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/review/service/ReviewServiceTest.java
@@ -1,0 +1,297 @@
+package com.awad.ticketbooking.modules.review.service;
+
+import com.awad.ticketbooking.common.enums.BookingStatus;
+import com.awad.ticketbooking.common.enums.TripStatus;
+import com.awad.ticketbooking.modules.auth.entity.User;
+import com.awad.ticketbooking.modules.booking.entity.Booking;
+import com.awad.ticketbooking.modules.booking.repository.BookingRepository;
+import com.awad.ticketbooking.modules.catalog.entity.Route;
+import com.awad.ticketbooking.modules.catalog.entity.Station;
+import com.awad.ticketbooking.modules.review.dto.CreateReviewRequest;
+import com.awad.ticketbooking.modules.review.dto.OperatorStatsResponse;
+import com.awad.ticketbooking.modules.review.dto.ReviewResponse;
+import com.awad.ticketbooking.modules.review.entity.Review;
+import com.awad.ticketbooking.modules.review.repository.ReviewRepository;
+import com.awad.ticketbooking.modules.trip.entity.Trip;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ReviewServiceTest {
+
+    @InjectMocks
+    private ReviewService reviewService;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @Mock
+    private BookingRepository bookingRepository;
+
+    private Booking testBooking;
+    private User testUser;
+    private Trip testTrip;
+    private Review testReview;
+    private UUID operatorId;
+
+    @BeforeEach
+    void setUp() {
+        operatorId = UUID.randomUUID();
+
+        // Setup stations
+        Station originStation = new Station();
+        originStation.setId(UUID.randomUUID());
+        originStation.setName("Hanoi");
+        originStation.setCity("Hanoi");
+
+        Station destStation = new Station();
+        destStation.setId(UUID.randomUUID());
+        destStation.setName("Saigon");
+        destStation.setCity("Saigon");
+
+        // Setup route
+        Route route = new Route();
+        route.setId(UUID.randomUUID());
+        route.setOriginStation(originStation);
+        route.setDestinationStation(destStation);
+
+        // Setup user
+        testUser = User.builder()
+                .email("test@example.com")
+                .fullName("Test User")
+                .build();
+        testUser.setId(UUID.randomUUID());
+
+        // Setup trip
+        testTrip = new Trip();
+        testTrip.setId(UUID.randomUUID());
+        testTrip.setRoute(route);
+        testTrip.setStatus(TripStatus.COMPLETED);
+        testTrip.setDepartureTime(Instant.now().minusSeconds(86400));
+
+        // Setup booking
+        testBooking = new Booking();
+        testBooking.setId(UUID.randomUUID());
+        testBooking.setCode("BK-ABC123");
+        testBooking.setTrip(testTrip);
+        testBooking.setUser(testUser);
+        testBooking.setPassengerName("Test Passenger");
+        testBooking.setStatus(BookingStatus.CONFIRMED);
+
+        // Setup review
+        testReview = new Review();
+        testReview.setId(UUID.randomUUID());
+        testReview.setBooking(testBooking);
+        testReview.setRating(5);
+        testReview.setComment("Great service!");
+        testReview.setCreatedAt(Instant.now());
+    }
+
+    @Test
+    void createReview_success() {
+        // Arrange
+        CreateReviewRequest request = new CreateReviewRequest();
+        request.setBookingId(testBooking.getId());
+        request.setRating(5);
+        request.setComment("Great service!");
+
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+        when(reviewRepository.findByBookingId(testBooking.getId())).thenReturn(Optional.empty());
+        when(reviewRepository.save(any(Review.class))).thenReturn(testReview);
+
+        // Act
+        ReviewResponse response = reviewService.createReview(request, testUser.getId());
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(5, response.getRating());
+        assertEquals("Great service!", response.getComment());
+        verify(reviewRepository).save(any(Review.class));
+    }
+
+    @Test
+    void createReview_bookingNotFound_throwsException() {
+        // Arrange
+        CreateReviewRequest request = new CreateReviewRequest();
+        request.setBookingId(UUID.randomUUID());
+
+        when(bookingRepository.findById(request.getBookingId())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> reviewService.createReview(request, testUser.getId()));
+        assertEquals("Booking not found", exception.getMessage());
+    }
+
+    @Test
+    void createReview_bookingNotBelongToUser_throwsException() {
+        // Arrange
+        CreateReviewRequest request = new CreateReviewRequest();
+        request.setBookingId(testBooking.getId());
+
+        UUID differentUserId = UUID.randomUUID();
+
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> reviewService.createReview(request, differentUserId));
+        assertEquals("Booking does not belong to the user", exception.getMessage());
+    }
+
+    @Test
+    void createReview_tripNotCompleted_throwsException() {
+        // Arrange
+        testTrip.setStatus(TripStatus.RUNNING);
+
+        CreateReviewRequest request = new CreateReviewRequest();
+        request.setBookingId(testBooking.getId());
+
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> reviewService.createReview(request, testUser.getId()));
+        assertEquals("Cannot review a trip that is not completed", exception.getMessage());
+    }
+
+    @Test
+    void createReview_bookingNotConfirmed_throwsException() {
+        // Arrange
+        testBooking.setStatus(BookingStatus.PENDING);
+
+        CreateReviewRequest request = new CreateReviewRequest();
+        request.setBookingId(testBooking.getId());
+
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> reviewService.createReview(request, testUser.getId()));
+        assertEquals("Cannot review a booking that is not confirmed", exception.getMessage());
+    }
+
+    @Test
+    void createReview_alreadyExists_throwsException() {
+        // Arrange
+        CreateReviewRequest request = new CreateReviewRequest();
+        request.setBookingId(testBooking.getId());
+
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+        when(reviewRepository.findByBookingId(testBooking.getId())).thenReturn(Optional.of(testReview));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> reviewService.createReview(request, testUser.getId()));
+        assertEquals("Review already exists for this booking", exception.getMessage());
+    }
+
+    @Test
+    void getReviewsByOperator_success() {
+        // Arrange
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Review> page = new PageImpl<>(Collections.singletonList(testReview));
+
+        when(reviewRepository.findByOperatorIdWithRouteInfo(operatorId, pageable)).thenReturn(page);
+
+        // Act
+        Page<ReviewResponse> response = reviewService.getReviewsByOperator(operatorId, pageable);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(1, response.getTotalElements());
+        assertEquals(5, response.getContent().get(0).getRating());
+    }
+
+    @Test
+    void getReviewByBookingId_found_success() {
+        // Arrange
+        when(reviewRepository.findByBookingId(testBooking.getId())).thenReturn(Optional.of(testReview));
+
+        // Act
+        ReviewResponse response = reviewService.getReviewByBookingId(testBooking.getId());
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(5, response.getRating());
+        assertEquals("Great service!", response.getComment());
+    }
+
+    @Test
+    void getReviewByBookingId_notFound_returnsNull() {
+        // Arrange
+        when(reviewRepository.findByBookingId(testBooking.getId())).thenReturn(Optional.empty());
+
+        // Act
+        ReviewResponse response = reviewService.getReviewByBookingId(testBooking.getId());
+
+        // Assert
+        assertNull(response);
+    }
+
+    @Test
+    void getOperatorStats_success() {
+        // Arrange
+        when(reviewRepository.findAverageRatingByOperatorId(operatorId)).thenReturn(4.5);
+        when(reviewRepository.countByOperatorId(operatorId)).thenReturn(10L);
+
+        // Act
+        OperatorStatsResponse response = reviewService.getOperatorStats(operatorId);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(4.5, response.getAverageRating());
+        assertEquals(10L, response.getTotalReviews());
+    }
+
+    @Test
+    void getOperatorStats_noReviews_returnsDefaults() {
+        // Arrange
+        when(reviewRepository.findAverageRatingByOperatorId(operatorId)).thenReturn(null);
+        when(reviewRepository.countByOperatorId(operatorId)).thenReturn(null);
+
+        // Act
+        OperatorStatsResponse response = reviewService.getOperatorStats(operatorId);
+
+        // Assert
+        assertNotNull(response);
+        assertNull(response.getAverageRating());
+        assertEquals(0L, response.getTotalReviews());
+    }
+
+    @Test
+    void createReview_guestBooking_throwsException() {
+        // Arrange
+        testBooking.setUser(null); // Guest booking
+
+        CreateReviewRequest request = new CreateReviewRequest();
+        request.setBookingId(testBooking.getId());
+
+        when(bookingRepository.findById(testBooking.getId())).thenReturn(Optional.of(testBooking));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> reviewService.createReview(request, testUser.getId()));
+        assertEquals("Booking does not belong to the user", exception.getMessage());
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/trip/controller/TripControllerTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/trip/controller/TripControllerTest.java
@@ -1,0 +1,250 @@
+package com.awad.ticketbooking.modules.trip.controller;
+
+import com.awad.ticketbooking.common.enums.TripStatus;
+import com.awad.ticketbooking.modules.trip.dto.CreateTripRequest;
+import com.awad.ticketbooking.modules.trip.dto.PricingRequest;
+import com.awad.ticketbooking.modules.trip.dto.TripResponse;
+import com.awad.ticketbooking.modules.trip.service.TripService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class TripControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private TripService tripService;
+
+    @InjectMocks
+    private TripController tripController;
+
+    private ObjectMapper objectMapper;
+    private TripResponse mockTripResponse;
+
+    @BeforeEach
+    void setUp() {
+        PageableHandlerMethodArgumentResolver pageableResolver = new PageableHandlerMethodArgumentResolver();
+        pageableResolver.setFallbackPageable(PageRequest.of(0, 20));
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        org.springframework.http.converter.json.MappingJackson2HttpMessageConverter converter = 
+                new org.springframework.http.converter.json.MappingJackson2HttpMessageConverter(objectMapper);
+        mockMvc = MockMvcBuilders.standaloneSetup(tripController)
+                .setCustomArgumentResolvers(pageableResolver)
+                .setMessageConverters(converter)
+                .build();
+
+        mockTripResponse = TripResponse.builder()
+                .id(UUID.randomUUID())
+                .departureTime(Instant.now().plusSeconds(3600))
+                .arrivalTime(Instant.now().plusSeconds(7200))
+                .status(TripStatus.SCHEDULED)
+                .build();
+    }
+
+    @Test
+    void searchTrips_success() throws Exception {
+        // Arrange
+        Page<TripResponse> page = new PageImpl<>(Arrays.asList(mockTripResponse), PageRequest.of(0, 10), 1);
+        when(tripService.searchTrips(any())).thenReturn(page);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/trips/search")
+                        .param("origin", "Ho Chi Minh")
+                        .param("destination", "Ha Noi"))
+                .andExpect(status().isOk());
+
+        verify(tripService).searchTrips(any());
+    }
+
+    @Test
+    void getAllTrips_success() throws Exception {
+        // Arrange
+        Page<TripResponse> page = new PageImpl<>(Arrays.asList(mockTripResponse), PageRequest.of(0, 10), 1);
+        when(tripService.getAllTrips(any())).thenReturn(page);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/trips")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk());
+
+        verify(tripService).getAllTrips(any());
+    }
+
+    @Test
+    void getTripById_success() throws Exception {
+        // Arrange
+        UUID tripId = mockTripResponse.getId();
+        when(tripService.getTripById(tripId)).thenReturn(mockTripResponse);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/trips/{id}", tripId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(tripId.toString()));
+
+        verify(tripService).getTripById(tripId);
+    }
+
+    @Test
+    void createTrip_success() throws Exception {
+        // Arrange
+        CreateTripRequest request = new CreateTripRequest();
+        request.setRouteId(UUID.randomUUID());
+        request.setBusId(UUID.randomUUID());
+        request.setDepartureTime(Instant.now().plusSeconds(3600));
+        request.setArrivalTime(Instant.now().plusSeconds(7200));
+        PricingRequest pricing = new PricingRequest();
+        pricing.setSeatType(com.awad.ticketbooking.common.enums.SeatType.NORMAL);
+        pricing.setPrice(new BigDecimal("200000"));
+        request.setPricings(Arrays.asList(pricing));
+        when(tripService.createTrip(any(CreateTripRequest.class))).thenReturn(mockTripResponse);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/trips")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        verify(tripService).createTrip(any(CreateTripRequest.class));
+    }
+
+    @Test
+    void updateTrip_success() throws Exception {
+        // Arrange
+        UUID tripId = UUID.randomUUID();
+        CreateTripRequest request = new CreateTripRequest();
+        request.setRouteId(UUID.randomUUID());
+        request.setBusId(UUID.randomUUID());
+        request.setDepartureTime(Instant.now().plusSeconds(3600));
+        request.setArrivalTime(Instant.now().plusSeconds(7200));
+        PricingRequest pricing = new PricingRequest();
+        pricing.setSeatType(com.awad.ticketbooking.common.enums.SeatType.NORMAL);
+        pricing.setPrice(new BigDecimal("200000"));
+        request.setPricings(Arrays.asList(pricing));
+        when(tripService.updateTrip(eq(tripId), any(CreateTripRequest.class))).thenReturn(mockTripResponse);
+
+        // Act & Assert
+        mockMvc.perform(put("/api/trips/{id}", tripId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        verify(tripService).updateTrip(eq(tripId), any(CreateTripRequest.class));
+    }
+
+    @Test
+    void deleteTrip_success() throws Exception {
+        // Arrange
+        UUID tripId = UUID.randomUUID();
+        doNothing().when(tripService).deleteTrip(tripId, false);
+
+        // Act & Assert
+        mockMvc.perform(delete("/api/trips/{id}", tripId))
+                .andExpect(status().isNoContent());
+
+        verify(tripService).deleteTrip(tripId, false);
+    }
+
+    @Test
+    void deleteTrip_withForce_success() throws Exception {
+        // Arrange
+        UUID tripId = UUID.randomUUID();
+        doNothing().when(tripService).deleteTrip(tripId, true);
+
+        // Act & Assert
+        mockMvc.perform(delete("/api/trips/{id}", tripId)
+                        .param("force", "true"))
+                .andExpect(status().isNoContent());
+
+        verify(tripService).deleteTrip(tripId, true);
+    }
+
+    @Test
+    void updateTripStops_success() throws Exception {
+        // Arrange
+        UUID tripId = mockTripResponse.getId();
+        com.awad.ticketbooking.modules.trip.dto.UpdateTripStopsRequest request = 
+                new com.awad.ticketbooking.modules.trip.dto.UpdateTripStopsRequest();
+        request.setStops(java.util.Collections.emptyList());
+        when(tripService.updateTripStops(eq(tripId), any())).thenReturn(mockTripResponse);
+
+        // Act & Assert
+        mockMvc.perform(put("/api/trips/{id}/stops", tripId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        verify(tripService).updateTripStops(eq(tripId), any());
+    }
+
+    @Test
+    void getTripPassengers_success() throws Exception {
+        // Arrange
+        UUID tripId = UUID.randomUUID();
+        List<com.awad.ticketbooking.modules.trip.dto.TripPassengerResponse> passengers = Arrays.asList();
+        when(tripService.getTripPassengers(tripId)).thenReturn(passengers);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/trips/{id}/passengers", tripId))
+                .andExpect(status().isOk());
+
+        verify(tripService).getTripPassengers(tripId);
+    }
+
+    @Test
+    void updateTripStatus_success() throws Exception {
+        // Arrange
+        UUID tripId = UUID.randomUUID();
+        TripStatus status = TripStatus.RUNNING;
+        when(tripService.updateTripStatus(tripId, status)).thenReturn(mockTripResponse);
+
+        // Act & Assert
+        mockMvc.perform(patch("/api/trips/{id}/status", tripId)
+                        .param("status", "RUNNING"))
+                .andExpect(status().isOk());
+
+        verify(tripService).updateTripStatus(tripId, status);
+    }
+
+    @Test
+    void checkCanUpdateRecurrence_success() throws Exception {
+        // Arrange
+        UUID tripId = UUID.randomUUID();
+        TripService.RecurrenceUpdateCheck check = new TripService.RecurrenceUpdateCheck(true, 0L);
+        when(tripService.checkCanUpdateRecurrence(tripId)).thenReturn(check);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/trips/{id}/can-update-recurrence", tripId))
+                .andExpect(status().isOk());
+
+        verify(tripService).checkCanUpdateRecurrence(tripId);
+    }
+}

--- a/backend/src/test/java/com/awad/ticketbooking/modules/trip/service/TripServiceTest.java
+++ b/backend/src/test/java/com/awad/ticketbooking/modules/trip/service/TripServiceTest.java
@@ -1,47 +1,139 @@
 package com.awad.ticketbooking.modules.trip.service;
 
+import com.awad.ticketbooking.common.enums.BookingStatus;
+import com.awad.ticketbooking.common.enums.StopType;
+import com.awad.ticketbooking.common.enums.TripStatus;
+import com.awad.ticketbooking.modules.booking.entity.Booking;
+import com.awad.ticketbooking.modules.booking.repository.BookingRepository;
+import com.awad.ticketbooking.modules.booking.repository.TicketRepository;
+import com.awad.ticketbooking.modules.booking.service.BookingService;
 import com.awad.ticketbooking.modules.catalog.entity.Bus;
 import com.awad.ticketbooking.modules.catalog.entity.Operator;
 import com.awad.ticketbooking.modules.catalog.entity.BusLayout;
 import com.awad.ticketbooking.modules.catalog.entity.Route;
 import com.awad.ticketbooking.modules.catalog.entity.Station;
+import com.awad.ticketbooking.modules.catalog.repository.BusRepository;
+import com.awad.ticketbooking.modules.catalog.repository.RouteRepository;
+import com.awad.ticketbooking.modules.catalog.repository.StationRepository;
+import com.awad.ticketbooking.modules.trip.dto.CreateTripRequest;
 import com.awad.ticketbooking.modules.trip.dto.SearchTripRequest;
 import com.awad.ticketbooking.modules.trip.dto.TripResponse;
+import com.awad.ticketbooking.modules.trip.dto.TripStopDto;
+import com.awad.ticketbooking.modules.trip.dto.UpdateTripStopsRequest;
 import com.awad.ticketbooking.modules.trip.entity.Trip;
 import com.awad.ticketbooking.modules.trip.repository.TripPricingRepository;
 import com.awad.ticketbooking.modules.trip.repository.TripRepository;
+import com.awad.ticketbooking.modules.trip.repository.TripScheduleRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.ArgumentMatchers;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class TripServiceTest {
 
     @Mock
     private TripRepository tripRepository;
-
     @Mock
     private TripPricingRepository tripPricingRepository;
+    @Mock
+    private BusRepository busRepository;
+    @Mock
+    private RouteRepository routeRepository;
+    @Mock
+    private StationRepository stationRepository;
+    @Mock
+    private BookingRepository bookingRepository;
+    @Mock
+    private TicketRepository ticketRepository;
+    @Mock
+    private TripScheduleRepository tripScheduleRepository;
+    @Mock
+    private BookingService bookingService;
+    @Mock
+    private ObjectMapper objectMapper;
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
 
     @InjectMocks
     private TripService tripService;
+
+    private Trip testTrip;
+    private Bus testBus;
+    private Route testRoute;
+    private Station originStation;
+    private Station destinationStation;
+
+    @BeforeEach
+    void setUp() {
+        originStation = new Station();
+        originStation.setId(UUID.randomUUID());
+        originStation.setName("Hanoi Station");
+        originStation.setCity("Hanoi");
+
+        destinationStation = new Station();
+        destinationStation.setId(UUID.randomUUID());
+        destinationStation.setName("Saigon Station");
+        destinationStation.setCity("Saigon");
+
+        Operator operator = new Operator();
+        operator.setId(UUID.randomUUID());
+        operator.setName("Test Operator");
+
+        BusLayout layout = new BusLayout();
+        layout.setId(UUID.randomUUID());
+        layout.setTotalSeats(40);
+
+        testBus = new Bus();
+        testBus.setId(UUID.randomUUID());
+        testBus.setPlateNumber("29A-12345");
+        testBus.setOperator(operator);
+        testBus.setBusLayout(layout);
+        testBus.setAmenities(Collections.singletonList("wifi"));
+
+        testRoute = new Route();
+        testRoute.setId(UUID.randomUUID());
+        testRoute.setOriginStation(originStation);
+        testRoute.setDestinationStation(destinationStation);
+        testRoute.setDurationMinutes(360);
+        testRoute.setStops(new ArrayList<>());
+
+        testTrip = new Trip();
+        testTrip.setId(UUID.randomUUID());
+        testTrip.setRoute(testRoute);
+        testTrip.setBus(testBus);
+        testTrip.setDepartureTime(Instant.now().plusSeconds(3600));
+        testTrip.setArrivalTime(Instant.now().plusSeconds(7200));
+        testTrip.setStatus(TripStatus.SCHEDULED);
+        testTrip.setTripStops(new ArrayList<>());
+        testTrip.setTripPricings(new ArrayList<>());
+    }
 
     @Test
     void searchTrips_shouldReturnTrips() {
@@ -140,5 +232,382 @@ class TripServiceTest {
         assertEquals("Hanoi", result.getRoute().getOriginStation().getCity());
 
         verify(tripRepository).findById(tripId);
+    }
+
+    @Test
+    void createTrip_success() {
+        // Arrange
+        CreateTripRequest request = new CreateTripRequest();
+        request.setRouteId(testRoute.getId());
+        request.setBusId(testBus.getId());
+        request.setDepartureTime(Instant.now().plusSeconds(3600));
+        request.setArrivalTime(Instant.now().plusSeconds(7200));
+        request.setTripType("ONE_TIME");
+
+        when(routeRepository.findById(testRoute.getId())).thenReturn(Optional.of(testRoute));
+        when(busRepository.findById(testBus.getId())).thenReturn(Optional.of(testBus));
+        when(tripRepository.existsByBusIdAndDepartureTimeLessThanAndArrivalTimeGreaterThan(
+                any(), any(), any())).thenReturn(false);
+        when(tripRepository.save(any(Trip.class))).thenAnswer(invocation -> {
+            Trip t = invocation.getArgument(0);
+            t.setId(UUID.randomUUID());
+            return t;
+        });
+
+        // Act
+        TripResponse result = tripService.createTrip(request);
+
+        // Assert
+        assertNotNull(result);
+        verify(tripRepository).save(any(Trip.class));
+    }
+
+    @Test
+    void createTrip_routeNotFound_throwsException() {
+        // Arrange
+        CreateTripRequest request = new CreateTripRequest();
+        request.setRouteId(UUID.randomUUID());
+        when(routeRepository.findById(request.getRouteId())).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> tripService.createTrip(request));
+        assertTrue(exception.getMessage().contains("Route not found"));
+    }
+
+    @Test
+    void createTrip_busConflict_throwsException() {
+        // Arrange
+        CreateTripRequest request = new CreateTripRequest();
+        request.setRouteId(testRoute.getId());
+        request.setBusId(testBus.getId());
+        request.setDepartureTime(Instant.now().plusSeconds(3600));
+        request.setArrivalTime(Instant.now().plusSeconds(7200));
+
+        when(routeRepository.findById(testRoute.getId())).thenReturn(Optional.of(testRoute));
+        when(busRepository.findById(testBus.getId())).thenReturn(Optional.of(testBus));
+        when(tripRepository.existsByBusIdAndDepartureTimeLessThanAndArrivalTimeGreaterThan(
+                any(), any(), any())).thenReturn(true);
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> tripService.createTrip(request));
+        assertTrue(exception.getMessage().contains("already assigned"));
+    }
+
+    @Test
+    void updateTrip_success() {
+        // Arrange
+        CreateTripRequest request = new CreateTripRequest();
+        request.setRouteId(testRoute.getId());
+        request.setBusId(testBus.getId());
+        request.setDepartureTime(Instant.now().plusSeconds(3600));
+        request.setArrivalTime(Instant.now().plusSeconds(7200));
+
+        when(tripRepository.findById(testTrip.getId())).thenReturn(Optional.of(testTrip));
+        when(bookingRepository.existsByTripId(testTrip.getId())).thenReturn(false);
+        when(busRepository.findById(testBus.getId())).thenReturn(Optional.of(testBus));
+        when(routeRepository.findById(testRoute.getId())).thenReturn(Optional.of(testRoute));
+        when(tripRepository.existsByBusIdAndDepartureTimeLessThanAndArrivalTimeGreaterThanAndIdNot(
+                any(), any(), any(), any())).thenReturn(false);
+        when(tripRepository.save(any(Trip.class))).thenReturn(testTrip);
+
+        // Act
+        TripResponse result = tripService.updateTrip(testTrip.getId(), request);
+
+        // Assert
+        assertNotNull(result);
+        verify(tripRepository).save(any(Trip.class));
+    }
+
+    @Test
+    void updateTrip_hasBookings_throwsException() {
+        // Arrange
+        CreateTripRequest request = new CreateTripRequest();
+        when(tripRepository.findById(testTrip.getId())).thenReturn(Optional.of(testTrip));
+        when(bookingRepository.existsByTripId(testTrip.getId())).thenReturn(true);
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> tripService.updateTrip(testTrip.getId(), request));
+        assertTrue(exception.getMessage().contains("existing bookings"));
+    }
+
+    @Test
+    void deleteTrip_withoutForce_noActiveBookings() {
+        // Arrange
+        when(tripRepository.findById(testTrip.getId())).thenReturn(Optional.of(testTrip));
+        when(bookingRepository.findByTripId(testTrip.getId())).thenReturn(Collections.emptyList());
+        when(tripRepository.save(any(Trip.class))).thenReturn(testTrip);
+
+        // Act
+        assertDoesNotThrow(() -> tripService.deleteTrip(testTrip.getId(), false));
+
+        // Assert
+        verify(tripRepository).save(any(Trip.class));
+        assertEquals(TripStatus.CANCELLED, testTrip.getStatus());
+    }
+
+    @Test
+    void deleteTrip_withoutForce_hasActiveBookings_throwsException() {
+        // Arrange
+        Booking booking = new Booking();
+        booking.setStatus(BookingStatus.CONFIRMED);
+        when(tripRepository.findById(testTrip.getId())).thenReturn(Optional.of(testTrip));
+        when(bookingRepository.findByTripId(testTrip.getId())).thenReturn(Collections.singletonList(booking));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> tripService.deleteTrip(testTrip.getId(), false));
+        assertTrue(exception.getMessage().contains("active bookings"));
+    }
+
+    @Test
+    void deleteTrip_withForce_refundsConfirmedBookings() {
+        // Arrange
+        Booking confirmedBooking = new Booking();
+        confirmedBooking.setId(UUID.randomUUID());
+        confirmedBooking.setStatus(BookingStatus.CONFIRMED);
+        confirmedBooking.setTrip(testTrip);
+
+        Booking pendingBooking = new Booking();
+        pendingBooking.setId(UUID.randomUUID());
+        pendingBooking.setStatus(BookingStatus.PENDING);
+        pendingBooking.setTrip(testTrip);
+
+        when(tripRepository.findById(testTrip.getId())).thenReturn(Optional.of(testTrip));
+        when(bookingRepository.findByTripId(testTrip.getId())).thenReturn(List.of(confirmedBooking, pendingBooking));
+        when(bookingService.refundBooking(confirmedBooking.getId())).thenReturn(null);
+        when(bookingService.cancelBooking(pendingBooking.getId())).thenReturn(null);
+        when(tripRepository.save(any(Trip.class))).thenReturn(testTrip);
+
+        // Act
+        assertDoesNotThrow(() -> tripService.deleteTrip(testTrip.getId(), true));
+
+        // Assert
+        verify(bookingService).refundBooking(confirmedBooking.getId());
+        verify(bookingService).cancelBooking(pendingBooking.getId());
+    }
+
+    @Test
+    void updateTripStops_success() {
+        // Arrange
+        UpdateTripStopsRequest request = new UpdateTripStopsRequest();
+        TripStopDto stopDto = new TripStopDto();
+        stopDto.setStationId(originStation.getId());
+        stopDto.setStopOrder(1);
+        stopDto.setDurationMinutesFromOrigin(60);
+        stopDto.setStopType(StopType.BOTH);
+        request.setStops(Collections.singletonList(stopDto));
+
+        when(tripRepository.findById(testTrip.getId())).thenReturn(Optional.of(testTrip));
+        when(stationRepository.existsById(originStation.getId())).thenReturn(true);
+        when(stationRepository.getReferenceById(originStation.getId())).thenReturn(originStation);
+        when(tripRepository.save(any(Trip.class))).thenReturn(testTrip);
+
+        // Act
+        TripResponse result = tripService.updateTripStops(testTrip.getId(), request);
+
+        // Assert
+        assertNotNull(result);
+        verify(tripRepository).save(any(Trip.class));
+    }
+
+    @Test
+    void updateTripStops_invalidStop_throwsException() {
+        // Arrange
+        UpdateTripStopsRequest request = new UpdateTripStopsRequest();
+        TripStopDto stopDto = new TripStopDto();
+        // Missing both stationId and customAddress
+        request.setStops(Collections.singletonList(stopDto));
+
+        when(tripRepository.findById(testTrip.getId())).thenReturn(Optional.of(testTrip));
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> tripService.updateTripStops(testTrip.getId(), request));
+        assertTrue(exception.getMessage().contains("must have either"));
+    }
+
+    @Test
+    void getAllTrips_success() {
+        // Arrange
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Trip> page = new PageImpl<>(Collections.singletonList(testTrip));
+        when(tripRepository.findAll(pageable)).thenReturn(page);
+
+        // Act
+        Page<TripResponse> result = tripService.getAllTrips(pageable);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+    }
+
+    @Test
+    void getTripById_notFound_throwsException() {
+        // Arrange
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.findById(tripId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> tripService.getTripById(tripId));
+        assertEquals("Trip not found", exception.getMessage());
+    }
+
+    @Test
+    void updateTripStatus_success() {
+        // Arrange
+        when(tripRepository.findById(testTrip.getId())).thenReturn(Optional.of(testTrip));
+        when(bookingRepository.findByTripIdAndStatus(any(), any())).thenReturn(Collections.emptyList());
+        when(tripRepository.save(any(Trip.class))).thenReturn(testTrip);
+
+        // Act
+        TripResponse result = tripService.updateTripStatus(testTrip.getId(), TripStatus.DELAYED);
+
+        // Assert
+        assertNotNull(result);
+        verify(tripRepository).save(any(Trip.class));
+    }
+
+    @Test
+    void validateRecurrenceDateRange_valid() {
+        // Act
+        int days = tripService.validateRecurrenceDateRange(
+                LocalDate.now().plusDays(1),
+                LocalDate.now().plusDays(10));
+
+        // Assert
+        assertEquals(9, days);
+    }
+
+    @Test
+    void validateRecurrenceDateRange_exceedsMax_throwsException() {
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> tripService.validateRecurrenceDateRange(
+                        LocalDate.now().plusDays(1),
+                        LocalDate.now().plusDays(100)));
+        assertTrue(exception.getMessage().contains("tối đa"));
+    }
+
+    @Test
+    void validateRecurrenceDateRange_startInPast_throwsException() {
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> tripService.validateRecurrenceDateRange(
+                        LocalDate.now().minusDays(1),
+                        LocalDate.now().plusDays(10)));
+        assertTrue(exception.getMessage().contains("quá khứ"));
+    }
+
+    @Test
+    void validateRecurrenceDateRange_endBeforeStart_throwsException() {
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> tripService.validateRecurrenceDateRange(
+                        LocalDate.now().plusDays(10),
+                        LocalDate.now().plusDays(5)));
+        assertTrue(exception.getMessage().contains("sau ngày bắt đầu"));
+    }
+
+    @Test
+    void checkCanUpdateRecurrence_success() {
+        // Arrange
+        when(tripRepository.existsById(testTrip.getId())).thenReturn(true);
+        when(bookingRepository.countFutureBookingsByTripId(eq(testTrip.getId()), any())).thenReturn(0L);
+
+        // Act
+        TripService.RecurrenceUpdateCheck result = tripService.checkCanUpdateRecurrence(testTrip.getId());
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result.canUpdate());
+        assertEquals(0, result.futureBookingsCount());
+    }
+
+    @Test
+    void checkCanUpdateRecurrence_tripNotFound_throwsException() {
+        // Arrange
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(false);
+
+        // Act & Assert
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> tripService.checkCanUpdateRecurrence(tripId));
+        assertTrue(exception.getMessage().contains("Trip not found"));
+    }
+
+    @Test
+    void getTripPassengers_success() {
+        // Arrange
+        com.awad.ticketbooking.modules.booking.entity.Ticket ticket = new com.awad.ticketbooking.modules.booking.entity.Ticket();
+        ticket.setId(UUID.randomUUID());
+        ticket.setSeatCode("A1");
+        ticket.setPassengerName("Test Passenger");
+        ticket.setPassengerPhone("0123456789");
+        ticket.setBoarded(false);
+        
+        Booking booking = new Booking();
+        booking.setCode("BK-123");
+        booking.setStatus(BookingStatus.CONFIRMED);
+        booking.setPickupStation(originStation);
+        booking.setDropoffStation(destinationStation);
+        ticket.setBooking(booking);
+
+        when(ticketRepository.findAllByBookingTripId(testTrip.getId())).thenReturn(Collections.singletonList(ticket));
+
+        // Act
+        List<com.awad.ticketbooking.modules.trip.dto.TripPassengerResponse> result = tripService.getTripPassengers(testTrip.getId());
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("A1", result.get(0).getSeatCode());
+        assertEquals("Test Passenger", result.get(0).getPassengerName());
+        assertEquals("BK-123", result.get(0).getBookingCode());
+    }
+
+    @Test
+    void getTripPassengers_emptyList() {
+        // Arrange
+        when(ticketRepository.findAllByBookingTripId(testTrip.getId())).thenReturn(Collections.emptyList());
+
+        // Act
+        List<com.awad.ticketbooking.modules.trip.dto.TripPassengerResponse> result = tripService.getTripPassengers(testTrip.getId());
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    void getTripPassengers_nullStations_handlesGracefully() {
+        // Arrange
+        com.awad.ticketbooking.modules.booking.entity.Ticket ticket = new com.awad.ticketbooking.modules.booking.entity.Ticket();
+        ticket.setId(UUID.randomUUID());
+        ticket.setSeatCode("A1");
+        ticket.setPassengerName("Test Passenger");
+        ticket.setPassengerPhone("0123456789");
+        ticket.setBoarded(false);
+        
+        Booking booking = new Booking();
+        booking.setCode("BK-123");
+        booking.setStatus(BookingStatus.CONFIRMED);
+        booking.setPickupStation(null);
+        booking.setDropoffStation(null);
+        ticket.setBooking(booking);
+
+        when(ticketRepository.findAllByBookingTripId(testTrip.getId())).thenReturn(Collections.singletonList(ticket));
+
+        // Act
+        List<com.awad.ticketbooking.modules.trip.dto.TripPassengerResponse> result = tripService.getTripPassengers(testTrip.getId());
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("", result.get(0).getPickupStation());
+        assertEquals("", result.get(0).getDropoffStation());
     }
 }


### PR DESCRIPTION
- Added JaCoCo Maven plugin to the project for code coverage analysis, including configuration for execution and reporting.
- Updated Bus, Operator, and Station entities to ignore Hibernate lazy initialization properties during JSON serialization.
- Introduced unit tests for GlobalExceptionHandler, EmailService, DateUtils, and QrCodeUtils to ensure robust error handling and utility functionality.
- Created comprehensive tests for various services and controllers, including Booking, User, and Trip services, to validate business logic and API interactions.